### PR TITLE
fix(frontend): améliorer la lisibilité et le contraste en dark mode

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -27,7 +27,7 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@types/jest": "^30.0.0",
-        "@types/node": "^20",
+        "@types/node": "20.19.41",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "eslint": "^9",
@@ -36,7 +36,7 @@
         "jest-environment-jsdom": "^30.3.0",
         "tailwindcss": "^4",
         "ts-jest": "^29.4.9",
-        "typescript": "^5"
+        "typescript": "5.9.3"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -111,6 +111,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -674,6 +675,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -697,6 +699,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2320,6 +2323,7 @@
       "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "playwright": "1.59.1"
       },
@@ -3267,7 +3271,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -3288,7 +3291,6 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -3364,8 +3366,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -3582,9 +3583,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.39",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
-      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "version": "20.19.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
+      "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3597,6 +3598,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3607,6 +3609,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3693,6 +3696,7 @@
       "integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.0",
         "@typescript-eslint/types": "8.58.0",
@@ -4225,6 +4229,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4746,6 +4751,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -5429,7 +5435,6 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -5478,8 +5483,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -5779,6 +5783,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5964,6 +5969,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -7685,6 +7691,7 @@
       "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.3.0",
         "@jest/types": "30.3.0",
@@ -8703,6 +8710,7 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -9197,7 +9205,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -10111,7 +10118,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -10127,7 +10133,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -10140,8 +10145,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -10224,6 +10228,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10233,6 +10238,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -10245,6 +10251,7 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.72.1.tgz",
       "integrity": "sha512-RhwBoy2ygeVZje+C+bwJ8g0NjTdBmDlJvAUHTxRjTmSUKPYsKfMphkS2sgEMotsY03bP358yEYlnUeZy//D9Ig==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -10268,6 +10275,7 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -10403,7 +10411,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -11444,6 +11453,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11761,6 +11771,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12435,6 +12446,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,7 +30,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@types/jest": "^30.0.0",
-    "@types/node": "^20",
+    "@types/node": "20.19.41",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",
@@ -39,6 +39,6 @@
     "jest-environment-jsdom": "^30.3.0",
     "tailwindcss": "^4",
     "ts-jest": "^29.4.9",
-    "typescript": "^5"
+    "typescript": "5.9.3"
   }
 }

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1,32 +1,168 @@
 @import "tailwindcss";
-:root { --bg:#f9fafb;--bg-card:#fff;--bg-hover:#f3f4f6;--border:#e5e7eb;--text-primary:#111827;--text-secondary:#374151;--text-muted:#9ca3af;--input-bg:#fff;--input-border:#d1d5db;--input-text:#111827;--sidebar-bg:#fff;--sidebar-border:#e5e7eb;--sidebar-active-bg:#eef2ff;--sidebar-active-text:#4338ca;--sidebar-text:#4b5563;--sidebar-hover:#f3f4f6; }
-html.dark { --bg:#0f1117;--bg-card:#1a1d2e;--bg-hover:#1e2235;--border:#2d3348;--text-primary:#f3f4f6;--text-secondary:#d1d5db;--text-muted:#6b7280;--input-bg:#1e2235;--input-border:#374151;--input-text:#f3f4f6;--sidebar-bg:#141725;--sidebar-border:#2d3348;--sidebar-active-bg:rgba(99,102,241,0.15);--sidebar-active-text:#a5b4fc;--sidebar-text:#9ca3af;--sidebar-hover:#1e2235; }
+
+/* ── LIGHT MODE TOKENS ───────────────────────────────────────── */
+:root {
+  --bg:#f9fafb; --bg-card:#fff; --bg-hover:#f3f4f6; --border:#e5e7eb;
+  --text-primary:#111827; --text-secondary:#374151; --text-muted:#9ca3af;
+  --input-bg:#fff; --input-border:#d1d5db; --input-text:#111827;
+  --sidebar-bg:#fff; --sidebar-border:#e5e7eb;
+  --sidebar-active-bg:#eef2ff; --sidebar-active-text:#4338ca;
+  --sidebar-text:#4b5563; --sidebar-hover:#f3f4f6;
+}
+
+/* ── DARK MODE TOKENS ────────────────────────────────────────── */
+html.dark {
+  --bg:#0f1117; --bg-card:#1a1d2e; --bg-hover:#1e2235; --border:#2d3348;
+  --text-primary:#f3f4f6; --text-secondary:#d1d5db; --text-muted:#9ca3af;
+  --input-bg:#1e2235; --input-border:#374151; --input-text:#f3f4f6;
+  --sidebar-bg:#141725; --sidebar-border:#2d3348;
+  --sidebar-active-bg:rgba(99,102,241,0.15); --sidebar-active-text:#a5b4fc;
+  --sidebar-text:#9ca3af; --sidebar-hover:#1e2235;
+}
+
+/* ── BASE ────────────────────────────────────────────────────── */
 body { background:var(--bg); color:var(--text-primary); font-family:Arial,Helvetica,sans-serif; }
 input,textarea,select { color:var(--input-text); background-color:var(--input-bg); border-color:var(--input-border); }
 input::placeholder,textarea::placeholder { color:var(--text-muted); }
-html.dark .bg-white { background-color:var(--bg-card)!important; }
-html.dark .bg-gray-50 { background-color:var(--bg)!important; }
-html.dark .bg-gray-100 { background-color:var(--bg-hover)!important; }
-html.dark .border-gray-200,html.dark .border-gray-300 { border-color:var(--border)!important; }
-html.dark .text-gray-900,html.dark .text-gray-800 { color:var(--text-primary)!important; }
-html.dark .text-gray-700,html.dark .text-gray-600 { color:var(--text-secondary)!important; }
-html.dark .text-gray-500,html.dark .text-gray-400 { color:var(--text-muted)!important; }
-html.dark .bg-indigo-50 { background-color:rgba(99,102,241,0.1)!important; }
-html.dark .bg-indigo-100 { background-color:rgba(99,102,241,0.15)!important; }
-html.dark .text-indigo-700 { color:#a5b4fc!important; }
-html.dark .bg-blue-50 { background-color:rgba(59,130,246,0.1)!important; }
-html.dark .text-blue-600 { color:#93c5fd!important; }
-html.dark .bg-green-50 { background-color:rgba(34,197,94,0.1)!important; }
-html.dark .text-green-600 { color:#86efac!important; }
-html.dark .bg-purple-50 { background-color:rgba(168,85,247,0.1)!important; }
-html.dark .bg-red-50 { background-color:rgba(239,68,68,0.08)!important; }
-html.dark .text-red-600 { color:#f87171!important; }
-html.dark .bg-emerald-100 { background-color:rgba(16,185,129,0.15)!important; }
-html.dark .text-emerald-700 { color:#6ee7b7!important; }
-html.dark .shadow-sm,html.dark .shadow-md { box-shadow:0 4px 6px -1px rgba(0,0,0,0.4)!important; }
-html.dark .hover\:shadow-md:hover { box-shadow:0 4px 12px -1px rgba(0,0,0,0.5)!important; }
-html.dark .hover\:bg-gray-50:hover,html.dark .hover\:bg-gray-100:hover { background-color:var(--bg-hover)!important; }
+
+/* ── DARK MODE OVERRIDES ─────────────────────────────────────── */
+
+/* --- GRAY ---------------------------------------------------- */
+html.dark .bg-white            { background-color:var(--bg-card)!important; }
+html.dark .bg-gray-50          { background-color:var(--bg)!important; }
+html.dark .bg-gray-100         { background-color:var(--bg-hover)!important; }
+html.dark .border-gray-200,
+html.dark .border-gray-300     { border-color:var(--border)!important; }
+html.dark .text-gray-900,
+html.dark .text-gray-800       { color:var(--text-primary)!important; }
+html.dark .text-gray-700,
+html.dark .text-gray-600       { color:var(--text-secondary)!important; }
+html.dark .text-gray-500,
+html.dark .text-gray-400,
+html.dark .text-gray-300       { color:var(--text-muted)!important; }
+html.dark .hover\:bg-gray-50:hover,
+html.dark .hover\:bg-gray-100:hover { background-color:var(--bg-hover)!important; }
+
+/* --- SLATE --------------------------------------------------- */
+html.dark .bg-slate-50         { background-color:var(--bg)!important; }
+html.dark .bg-slate-100        { background-color:var(--bg-hover)!important; }
+html.dark .bg-slate-200        { background-color:#2d3348!important; }
+html.dark .border-slate-100    { border-color:rgba(45,51,72,0.6)!important; }
+html.dark .border-slate-200,
+html.dark .border-slate-300    { border-color:var(--border)!important; }
+html.dark .text-slate-900,
+html.dark .text-slate-800      { color:var(--text-primary)!important; }
+html.dark .text-slate-700,
+html.dark .text-slate-600      { color:var(--text-secondary)!important; }
+html.dark .text-slate-500,
+html.dark .text-slate-400,
+html.dark .text-slate-300      { color:var(--text-muted)!important; }
+html.dark .hover\:bg-slate-50:hover,
+html.dark .hover\:bg-slate-100:hover { background-color:var(--bg-hover)!important; }
+html.dark .hover\:bg-slate-300:hover { background-color:#3a4260!important; }
+html.dark .hover\:border-slate-300:hover { border-color:#3d4566!important; }
+
+/* Gradient stops — only light slate variants */
+html.dark .from-slate-50 { --tw-gradient-from:var(--bg)!important; }
+html.dark .to-slate-50   { --tw-gradient-to:var(--bg)!important; }
+html.dark .to-white      { --tw-gradient-to:var(--bg-card)!important; }
+
+/* --- INDIGO -------------------------------------------------- */
+html.dark .bg-indigo-50        { background-color:rgba(99,102,241,0.1)!important; }
+html.dark .bg-indigo-100       { background-color:rgba(99,102,241,0.15)!important; }
+html.dark .text-indigo-700     { color:#a5b4fc!important; }
+html.dark .border-indigo-200   { border-color:rgba(99,102,241,0.3)!important; }
 html.dark .hover\:bg-indigo-50:hover { background-color:rgba(99,102,241,0.12)!important; }
-html.dark .border-indigo-200 { border-color:rgba(99,102,241,0.3)!important; }
-html.dark input[type="range"] { accent-color:#6366f1; }
-*,*::before,*::after { transition:background-color 0.2s ease,border-color 0.2s ease,color 0.15s ease; }
+
+/* --- BLUE ---------------------------------------------------- */
+html.dark .bg-blue-50          { background-color:rgba(59,130,246,0.1)!important; }
+html.dark .bg-blue-100         { background-color:rgba(59,130,246,0.15)!important; }
+html.dark .text-blue-600       { color:#93c5fd!important; }
+html.dark .text-blue-700       { color:#60a5fa!important; }
+html.dark .text-blue-900       { color:#bfdbfe!important; }
+html.dark .border-blue-200,
+html.dark .border-blue-300     { border-color:rgba(59,130,246,0.3)!important; }
+html.dark .from-blue-50        { --tw-gradient-from:rgba(59,130,246,0.1)!important; }
+html.dark .to-indigo-50        { --tw-gradient-to:rgba(99,102,241,0.1)!important; }
+
+/* --- SKY ----------------------------------------------------- */
+html.dark .bg-sky-50           { background-color:rgba(14,165,233,0.1)!important; }
+html.dark .bg-sky-100          { background-color:rgba(14,165,233,0.15)!important; }
+html.dark .text-sky-700,
+html.dark .text-sky-800        { color:#7dd3fc!important; }
+html.dark .border-sky-200,
+html.dark .border-sky-300      { border-color:rgba(14,165,233,0.3)!important; }
+html.dark .hover\:bg-sky-100:hover { background-color:rgba(14,165,233,0.2)!important; }
+
+/* --- GREEN / EMERALD ---------------------------------------- */
+html.dark .bg-green-50         { background-color:rgba(34,197,94,0.1)!important; }
+html.dark .bg-green-100        { background-color:rgba(34,197,94,0.15)!important; }
+html.dark .text-green-600      { color:#86efac!important; }
+html.dark .text-green-700,
+html.dark .text-green-800      { color:#4ade80!important; }
+html.dark .border-green-200,
+html.dark .border-green-300    { border-color:rgba(34,197,94,0.3)!important; }
+html.dark .bg-emerald-50       { background-color:rgba(16,185,129,0.08)!important; }
+html.dark .bg-emerald-100      { background-color:rgba(16,185,129,0.15)!important; }
+html.dark .text-emerald-700    { color:#6ee7b7!important; }
+html.dark .text-emerald-800    { color:#34d399!important; }
+html.dark .from-emerald-50     { --tw-gradient-from:rgba(16,185,129,0.1)!important; }
+html.dark .to-teal-50          { --tw-gradient-to:rgba(20,184,166,0.1)!important; }
+
+/* --- PURPLE -------------------------------------------------- */
+html.dark .bg-purple-50        { background-color:rgba(168,85,247,0.1)!important; }
+html.dark .bg-purple-100       { background-color:rgba(168,85,247,0.15)!important; }
+html.dark .text-purple-600     { color:#c084fc!important; }
+html.dark .border-purple-200   { border-color:rgba(168,85,247,0.3)!important; }
+html.dark .from-purple-50      { --tw-gradient-from:rgba(168,85,247,0.1)!important; }
+html.dark .to-pink-50          { --tw-gradient-to:rgba(236,72,153,0.1)!important; }
+
+/* --- RED ----------------------------------------------------- */
+html.dark .bg-red-50           { background-color:rgba(239,68,68,0.08)!important; }
+html.dark .bg-red-100          { background-color:rgba(239,68,68,0.12)!important; }
+html.dark .text-red-600        { color:#f87171!important; }
+html.dark .text-red-700,
+html.dark .text-red-800        { color:#fca5a5!important; }
+html.dark .border-red-200,
+html.dark .border-red-300      { border-color:rgba(239,68,68,0.3)!important; }
+
+/* --- AMBER / YELLOW ----------------------------------------- */
+html.dark .bg-amber-50,
+html.dark .bg-yellow-50        { background-color:rgba(217,119,6,0.1)!important; }
+html.dark .bg-amber-100,
+html.dark .bg-yellow-100       { background-color:rgba(217,119,6,0.15)!important; }
+html.dark .text-amber-700,
+html.dark .text-yellow-700     { color:#fbbf24!important; }
+html.dark .text-amber-800,
+html.dark .text-amber-900,
+html.dark .text-yellow-800,
+html.dark .text-yellow-900     { color:#fcd34d!important; }
+html.dark .border-amber-200,
+html.dark .border-yellow-200   { border-color:rgba(217,119,6,0.3)!important; }
+html.dark .hover\:bg-amber-100:hover { background-color:rgba(217,119,6,0.2)!important; }
+
+/* --- ORANGE -------------------------------------------------- */
+html.dark .text-orange-600     { color:#fb923c!important; }
+
+/* --- CYAN ---------------------------------------------------- */
+html.dark .bg-cyan-50          { background-color:rgba(6,182,212,0.1)!important; }
+
+/* --- ROSE / PINK / TEAL / LIME ------------------------------ */
+html.dark .bg-rose-50          { background-color:rgba(244,63,94,0.08)!important; }
+html.dark .bg-pink-50          { background-color:rgba(236,72,153,0.08)!important; }
+html.dark .bg-teal-50          { background-color:rgba(20,184,166,0.1)!important; }
+html.dark .bg-lime-50          { background-color:rgba(132,204,22,0.1)!important; }
+
+/* --- SHADOWS ------------------------------------------------- */
+html.dark .shadow-sm,
+html.dark .shadow-md           { box-shadow:0 4px 6px -1px rgba(0,0,0,0.4)!important; }
+html.dark .hover\:shadow-md:hover,
+html.dark .hover\:shadow-lg:hover { box-shadow:0 4px 12px -1px rgba(0,0,0,0.5)!important; }
+
+/* --- INPUT RANGE --------------------------------------------- */
+html.dark input[type="range"]  { accent-color:#6366f1; }
+
+/* ── TRANSITIONS (all elements) ─────────────────────────────── */
+*,*::before,*::after {
+  transition:background-color 0.2s ease,border-color 0.2s ease,color 0.15s ease;
+}


### PR DESCRIPTION
- Ajoute les surcharges manquantes pour text-slate-* (900→400) en dark mode (seules text-gray-* étaient gérées, causant du texte noir sur fond noir)
- Corrige --text-muted de #6b7280 à #9ca3af en dark mode (ratio 3.25→6.4:1)
- Ajoute bg-slate-50/100/200 en dark mode
- Ajoute les fonds colorés manquants : amber, cyan, rose, pink, lime, teal, sky
- Ajoute les textes colorés correspondants pour maintenir la lisibilité
- Override les gradient stops (from-slate-50, from-blue-50, from-emerald-50...)
- Installe les dépendances frontend manquantes (node_modules était vide)