### PR TITLE
feat(matching): integrate fine-tuned BERT classifier into hybrid scor…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
 #Les miens
 .env
+
+# ML model binaries — store in model registry, not git
+*.safetensors
+*.bin
+backend/models/bert_matching/
 venv/
 .venv/
 .venv-phase2/

--- a/backend/ai_module/matching/__init__.py
+++ b/backend/ai_module/matching/__init__.py
@@ -1,6 +1,19 @@
 """Matching Module - Init"""
 
 # Keep package initialization lightweight.
-# Heavy submodules such as semantic_matcher should be imported explicitly
-# by the caller when needed.
+# Heavy submodules such as semantic_matcher and bert_classifier_adapter should be
+# imported explicitly by the caller when needed (they pull in torch/transformers).
+
+# Convenience re-exports for common use:
+#   from ai_module.matching import HybridConfig, HybridMatcher
+#   from ai_module.matching import BertClassifierAdapter
+from ai_module.matching.hybrid_matcher import HybridConfig, HybridMatcher
+from ai_module.matching.bert_classifier_adapter import BertClassifierAdapter, get_default_adapter
+
+__all__ = [
+    "HybridConfig",
+    "HybridMatcher",
+    "BertClassifierAdapter",
+    "get_default_adapter",
+]
 

--- a/backend/ai_module/matching/bert_classifier_adapter.py
+++ b/backend/ai_module/matching/bert_classifier_adapter.py
@@ -1,0 +1,136 @@
+"""BERT classifier adapter for camembert-based candidate/job compatibility scoring.
+
+The underlying model (CamembertForSequenceClassification) outputs 3 classes:
+  0 = incompatible, 1 = partial, 2 = compatible
+
+The adapter converts softmax probabilities to a continuous [0, 1] score via
+weighted class expectation:  score = 0.0*P(incompatible) + 0.5*P(partial) + 1.0*P(compatible)
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+try:
+    from transformers import AutoTokenizer, AutoModelForSequenceClassification
+    import torch
+
+    TRANSFORMERS_AVAILABLE = True
+except ImportError:
+    TRANSFORMERS_AVAILABLE = False
+    logger.warning("transformers/torch not installed — BertClassifierAdapter will be disabled.")
+
+
+class BertClassifierAdapter:
+    """Thin wrapper around a fine-tuned CamembertForSequenceClassification model."""
+
+    # Class-level weights: incompatible=0, partial=0.5, compatible=1.0
+    _CLASS_WEIGHTS = np.array([0.0, 0.5, 1.0], dtype=np.float32)
+
+    def __init__(self, model_dir: str | Path):
+        if not TRANSFORMERS_AVAILABLE:
+            raise RuntimeError(
+                "transformers and torch are required. "
+                "Install them with: pip install transformers torch"
+            )
+        model_dir = Path(model_dir)
+        if not model_dir.exists():
+            raise FileNotFoundError(f"Model directory not found: {model_dir}")
+
+        self._device = "cuda" if torch.cuda.is_available() else "cpu"
+        self._tokenizer = AutoTokenizer.from_pretrained(str(model_dir))
+        self._model = AutoModelForSequenceClassification.from_pretrained(str(model_dir))
+        self._model.to(self._device)
+        self._model.eval()
+        self._max_length = 384
+        logger.info("BertClassifierAdapter loaded from %s on %s", model_dir, self._device)
+
+    @classmethod
+    def load(cls, model_dir: str | Path) -> "BertClassifierAdapter":
+        return cls(model_dir)
+
+    def predict_score(self, candidate_text: str, job_text: str) -> float:
+        """Return a compatibility score in [0, 1].
+
+        Combines candidate and job text as a text-pair sequence and returns
+        the soft-label expectation over (incompatible=0, partial=0.5, compatible=1.0).
+        """
+        if not TRANSFORMERS_AVAILABLE:
+            return 0.0
+
+        try:
+            inputs = self._tokenizer(
+                candidate_text,
+                job_text,
+                return_tensors="pt",
+                truncation=True,
+                max_length=self._max_length,
+                padding=True,
+            )
+            inputs = {k: v.to(self._device) for k, v in inputs.items()}
+
+            with torch.no_grad():
+                logits = self._model(**inputs).logits
+
+            probs = torch.softmax(logits, dim=-1).cpu().numpy()[0]
+            score = float(np.dot(probs, self._CLASS_WEIGHTS))
+            return float(np.clip(score, 0.0, 1.0))
+
+        except Exception as exc:
+            logger.warning("BertClassifierAdapter.predict_score failed: %s", exc)
+            return 0.0
+
+    def predict_label(self, candidate_text: str, job_text: str) -> str:
+        """Return the top predicted label: 'incompatible', 'partial', or 'compatible'."""
+        if not TRANSFORMERS_AVAILABLE:
+            return "incompatible"
+        try:
+            inputs = self._tokenizer(
+                candidate_text,
+                job_text,
+                return_tensors="pt",
+                truncation=True,
+                max_length=self._max_length,
+                padding=True,
+            )
+            inputs = {k: v.to(self._device) for k, v in inputs.items()}
+            with torch.no_grad():
+                logits = self._model(**inputs).logits
+            label_id = int(torch.argmax(logits, dim=-1).item())
+            id2label = {0: "incompatible", 1: "partial", 2: "compatible"}
+            return id2label[label_id]
+        except Exception as exc:
+            logger.warning("BertClassifierAdapter.predict_label failed: %s", exc)
+            return "incompatible"
+
+    @property
+    def available(self) -> bool:
+        return TRANSFORMERS_AVAILABLE
+
+
+_default_adapter: Optional[BertClassifierAdapter] = None
+
+
+def get_default_adapter(model_dir: Optional[str | Path] = None) -> Optional[BertClassifierAdapter]:
+    """Lazy-load a shared adapter instance. Returns None if unavailable."""
+    global _default_adapter
+    if _default_adapter is not None:
+        return _default_adapter
+
+    if model_dir is None:
+        # Resolve relative to this file: backend/ai_module/matching/ -> backend/models/bert_matching/
+        model_dir = Path(__file__).parent.parent.parent / "models" / "bert_matching"
+
+    try:
+        _default_adapter = BertClassifierAdapter.load(model_dir)
+    except Exception as exc:
+        logger.warning("Could not load default BertClassifierAdapter: %s", exc)
+        return None
+
+    return _default_adapter

--- a/backend/ai_module/matching/hybrid_matcher.py
+++ b/backend/ai_module/matching/hybrid_matcher.py
@@ -1,0 +1,252 @@
+"""Hybrid matcher combining semantic, BERT classifier, skill cosine, and business signals.
+
+Weight breakdown (defaults from training config):
+  semantic          0.35  — sentence-transformer cosine similarity on full texts
+  cross_encoder     0.20  — deeper semantic re-ranking (falls back to semantic when unavailable)
+  bert_classifier   0.25  — fine-tuned camembert compatibility classifier
+  skill_cosine      0.12  — binary skill-vector cosine (CosineScorer)
+  business          0.08  — structured rules: experience, location, availability
+
+All weights must sum to 1.0; HybridConfig normalizes automatically if they don't.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class HybridConfig:
+    weight_semantic: float = 0.35
+    weight_cross_encoder: float = 0.20
+    weight_bert_classifier: float = 0.25
+    weight_skill_cosine: float = 0.12
+    weight_business: float = 0.08
+
+    def __post_init__(self) -> None:
+        total = (
+            self.weight_semantic
+            + self.weight_cross_encoder
+            + self.weight_bert_classifier
+            + self.weight_skill_cosine
+            + self.weight_business
+        )
+        if total <= 0:
+            raise ValueError("HybridConfig: all weights are zero.")
+        if abs(total - 1.0) > 1e-6:
+            logger.debug("HybridConfig: weights sum to %.4f — normalizing.", total)
+            self.weight_semantic /= total
+            self.weight_cross_encoder /= total
+            self.weight_bert_classifier /= total
+            self.weight_skill_cosine /= total
+            self.weight_business /= total
+
+
+class HybridMatcher:
+    """Combine multiple matchers into a single weighted score (0–100).
+
+    Parameters
+    ----------
+    config:
+        Weight configuration.
+    bert_classifier:
+        Pre-loaded BertClassifierAdapter. If None, the adapter is lazy-loaded
+        from the default model directory (backend/models/bert_matching/).
+    """
+
+    def __init__(
+        self,
+        config: Optional[HybridConfig] = None,
+        bert_classifier=None,
+    ) -> None:
+        self.config = config or HybridConfig()
+        self._bert = bert_classifier  # may be None; resolved lazily
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def score(
+        self,
+        candidate_text: str,
+        job_text: str,
+        candidate_skills: Optional[List[str]] = None,
+        criteria_skills: Optional[Dict[str, float]] = None,
+        business_signals: Optional[Dict[str, object]] = None,
+    ) -> Dict[str, object]:
+        """Return a hybrid score dict.
+
+        Parameters
+        ----------
+        candidate_text:
+            Free-text CV / candidate profile.
+        job_text:
+            Free-text job description / offer.
+        candidate_skills:
+            List of skill names the candidate has.
+        criteria_skills:
+            Dict {skill_name: weight_0_to_100} from recruiter criteria.
+        business_signals:
+            Optional structured signals, e.g.::
+
+                {
+                    "years_experience": 5,
+                    "required_experience": 3,
+                    "location_match": True,
+                    "available": True,
+                }
+
+        Returns
+        -------
+        dict with keys: score (0–100), component_scores, weights_used
+        """
+        cfg = self.config
+        components: Dict[str, float] = {}
+
+        # 1. Semantic score
+        components["semantic"] = self._semantic_score(candidate_text, job_text)
+
+        # 2. Cross-encoder score (fallback to semantic when unavailable)
+        components["cross_encoder"] = self._cross_encoder_score(candidate_text, job_text)
+
+        # 3. BERT classifier score
+        components["bert_classifier"] = self._bert_score(candidate_text, job_text)
+
+        # 4. Skill cosine score
+        components["skill_cosine"] = self._skill_cosine_score(
+            candidate_skills or [], criteria_skills or {}
+        )
+
+        # 5. Business rules score
+        components["business"] = self._business_score(business_signals or {})
+
+        # Weighted sum
+        raw = (
+            cfg.weight_semantic * components["semantic"]
+            + cfg.weight_cross_encoder * components["cross_encoder"]
+            + cfg.weight_bert_classifier * components["bert_classifier"]
+            + cfg.weight_skill_cosine * components["skill_cosine"]
+            + cfg.weight_business * components["business"]
+        )
+        final_score = float(np.clip(raw * 100, 0.0, 100.0))
+
+        return {
+            "score": final_score,
+            "component_scores": {k: round(v, 4) for k, v in components.items()},
+            "weights_used": {
+                "semantic": cfg.weight_semantic,
+                "cross_encoder": cfg.weight_cross_encoder,
+                "bert_classifier": cfg.weight_bert_classifier,
+                "skill_cosine": cfg.weight_skill_cosine,
+                "business": cfg.weight_business,
+            },
+        }
+
+    # ------------------------------------------------------------------
+    # Component scorers
+    # ------------------------------------------------------------------
+
+    def _semantic_score(self, candidate_text: str, job_text: str) -> float:
+        try:
+            from ai_module.matching.semantic_matcher import SemanticSkillMatcher
+
+            return SemanticSkillMatcher.semantic_similarity(candidate_text, job_text)
+        except Exception as exc:
+            logger.debug("Semantic scorer unavailable: %s", exc)
+            return 0.0
+
+    def _cross_encoder_score(self, candidate_text: str, job_text: str) -> float:
+        """Attempt a cross-encoder pass; fall back to semantic similarity."""
+        try:
+            from sentence_transformers import CrossEncoder
+
+            if not hasattr(self, "_cross_encoder_model"):
+                self._cross_encoder_model = CrossEncoder("cross-encoder/ms-marco-MiniLM-L-6-v2")
+            score = self._cross_encoder_model.predict([[candidate_text, job_text]])[0]
+            # ms-marco scores are logits; apply sigmoid
+            import math
+
+            return float(np.clip(1 / (1 + math.exp(-score)), 0.0, 1.0))
+        except Exception:
+            # Graceful fallback to standard semantic similarity
+            return self._semantic_score(candidate_text, job_text)
+
+    def _bert_score(self, candidate_text: str, job_text: str) -> float:
+        bert = self._get_bert()
+        if bert is None:
+            return 0.0
+        return bert.predict_score(candidate_text, job_text)
+
+    def _skill_cosine_score(
+        self,
+        candidate_skills: List[str],
+        criteria_skills: Dict[str, float],
+    ) -> float:
+        if not candidate_skills or not criteria_skills:
+            return 0.0
+        try:
+            from ai_module.matching.scorer import CosineScorer
+
+            all_skills = list(criteria_skills.keys())
+            result = CosineScorer.calculate_match_score(
+                candidate_skills, criteria_skills, all_skills
+            )
+            return float(result["score"]) / 100.0
+        except Exception as exc:
+            logger.debug("Skill cosine scorer failed: %s", exc)
+            return 0.0
+
+    def _business_score(self, signals: Dict[str, object]) -> float:
+        """Simple rules-based business score in [0, 1]."""
+        if not signals:
+            return 0.5  # neutral when no signals provided
+
+        score = 0.0
+        count = 0
+
+        # Experience
+        years_exp = signals.get("years_experience")
+        required_exp = signals.get("required_experience")
+        if years_exp is not None and required_exp is not None:
+            try:
+                ratio = float(years_exp) / max(float(required_exp), 1.0)
+                score += float(np.clip(ratio, 0.0, 1.0))
+            except (TypeError, ValueError):
+                score += 0.5
+            count += 1
+
+        # Location match
+        location_match = signals.get("location_match")
+        if location_match is not None:
+            score += 1.0 if location_match else 0.2
+            count += 1
+
+        # Availability
+        available = signals.get("available")
+        if available is not None:
+            score += 1.0 if available else 0.0
+            count += 1
+
+        return float(np.clip(score / max(count, 1), 0.0, 1.0))
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _get_bert(self):
+        if self._bert is not None:
+            return self._bert
+        try:
+            from ai_module.matching.bert_classifier_adapter import get_default_adapter
+
+            self._bert = get_default_adapter()
+        except Exception as exc:
+            logger.warning("Could not load BertClassifierAdapter: %s", exc)
+            self._bert = None
+        return self._bert


### PR DESCRIPTION
…ing pipeline

## What this adds

Introduces a two-layer extension to the existing matching stack:

### 1. BertClassifierAdapter  (ai_module/matching/bert_classifier_adapter.py) Wraps the fine-tuned `camembert-base` model (v2) that was trained to classify candidate/job text pairs into three compatibility classes:
  - 0 = incompatible
  - 1 = partial
  - 2 = compatible

The adapter converts the raw softmax distribution into a continuous [0, 1] score using weighted class expectation:
  score = 0.0 × P(incompatible) + 0.5 × P(partial) + 1.0 × P(compatible)

Key design choices:
- Lazy singleton: `get_default_adapter()` loads once, resolves the model path relative to the file location (→ backend/models/bert_matching/) automatically
- Graceful degradation: all public methods return safe defaults when `transformers`/`torch` are not installed, so the rest of the app is unaffected
- GPU-aware: uses CUDA when available, falls back to CPU

### 2. HybridMatcher + HybridConfig  (ai_module/matching/hybrid_matcher.py) A weighted ensemble that combines five orthogonal signals into a single 0–100 score:

  Signal              Default weight   Source
  ──────────────────────────────────────────────────────────────
  semantic            0.35             SemanticSkillMatcher (BAAI/bge-small-en)
  cross_encoder       0.20             sentence-transformers CrossEncoder
                                       (falls back to semantic if unavailable)
  bert_classifier     0.25             BertClassifierAdapter (camembert-base v2)
  skill_cosine        0.12             CosineScorer (binary skill-vector overlap)
  business            0.08             Rules: experience ratio, location, availability
  ──────────────────────────────────────────────────────────────

`HybridConfig` is a plain dataclass — weights are normalized automatically if they do not sum to 1.0. Each component returns 0.0 on failure, so a missing dependency degrades score rather than crashing.

### 3. Model files  (backend/models/bert_matching/) The five required files are stored locally:
  config.json, tokenizer.json, tokenizer_config.json,
  training_metrics.json, model.safetensors

The model.safetensors binary (442 MB) is excluded from git via a new .gitignore rule (*.safetensors, *.bin, backend/models/bert_matching/). It must be distributed separately (model registry / shared storage).

### 4. Updated __init__.py
Re-exports HybridConfig, HybridMatcher, BertClassifierAdapter, and get_default_adapter so callers need only:
  from ai_module.matching import HybridConfig, HybridMatcher

## Usage

    from ai_module.matching import BertClassifierAdapter, HybridConfig, HybridMatcher

    bert = BertClassifierAdapter.load("backend/models/bert_matching/")
    hybrid = HybridMatcher(
        config=HybridConfig(
            weight_semantic=0.35,
            weight_cross_encoder=0.20,
            weight_bert_classifier=0.25,
            weight_skill_cosine=0.12,
            weight_business=0.08,
        ),
        bert_classifier=bert,
    )

    result = hybrid.score(
        candidate_text="...",
        job_text="...",
        candidate_skills=["Python", "FastAPI"],
        criteria_skills={"Python": 80, "FastAPI": 60},
        business_signals={
            "years_experience": 4,
            "required_experience": 3,
            "location_match": True,
            "available": True,
        },
    )
    # result["score"]             → 0–100
    # result["component_scores"]  → per-signal breakdown
    # result["weights_used"]      → active weight configuration

## Model notes

Base model  : camembert-base (French RoBERTa)
Version     : v2
Max length  : 384 tokens
Test accuracy: 0.483  |  F1 macro: 0.444
Training loss: 4.09  (model is functional; further fine-tuning recommended)