### PR TITLE
feat(admin): module Administrateur (CRUD utilisateurs, stats, monitoring, config pipeline IA)

### DIFF
--- a/ADMIN_MODULE.md
+++ b/ADMIN_MODULE.md
@@ -1,0 +1,290 @@
+# Module Administrateur — AI Talent Finder
+
+Implémentation de la **partie Administrateur** basée sur le diagramme de cas
+d'utilisation (`PFA.EAP`, package « Administrateur »).
+
+Ce document décrit **tous les changements apportés** et **comment tout tester**.
+
+---
+
+## 1. Cas d'utilisation couverts
+
+| Use case (diagramme) | Endpoint(s) backend | Page frontend |
+|---|---|---|
+| **S'authentifier** | `POST /api/auth/login` (existant) | `/auth/login` |
+| **Gérer les utilisateurs (CRUD)** | `GET/POST/PATCH/DELETE /api/admin/users` | `/admin/users` |
+| **Consulter les statistiques globales** | `GET /api/admin/stats` | `/admin/dashboard` |
+| **Superviser les logs et performances** | `GET /api/admin/logs`, `GET /api/admin/health` | `/admin/monitoring` |
+| **Configurer les paramètres du pipeline IA** | `GET/PUT /api/admin/pipeline-config`, `POST /api/admin/pipeline-config/reset` | `/admin/pipeline` |
+
+Toutes les routes `/api/admin/*` exigent un utilisateur authentifié avec le rôle
+`admin` (sinon **403 Forbidden**).
+
+---
+
+## 2. Changements — Backend (`backend/app/`)
+
+### Nouveaux fichiers
+| Fichier | Rôle |
+|---|---|
+| `api/admin.py` | Routeur `/api/admin/*` : users CRUD, stats, logs, health, pipeline-config. Protégé par `require_admin`. |
+| `schemas/admin.py` | Schémas Pydantic (AdminUserCreate/Update/Response, GlobalStats, ActivityLog, SystemHealth, PipelineConfig…). |
+| `core/settings_store.py` | Store de configuration du pipeline IA (poids + seuils), persisté en base et mis en cache mémoire. Source de vérité du scoring. |
+
+### Fichiers modifiés
+| Fichier | Modification |
+|---|---|
+| `models/models.py` | + modèles `SystemSetting` (config clé/valeur JSON) et `ActivityLog` (journal d'audit). |
+| `core/dependencies.py` | + `require_admin` (garde rôle admin) et `log_activity()` (audit best-effort). |
+| `services/scoring.py` | Les poids (50/20/15/10) et seuils (0.8/0.5) sont désormais lus depuis `settings_store` (valeurs par défaut **identiques** → comportement inchangé tant qu'un admin ne modifie rien). |
+| `api/auth.py` | Journalise l'événement `auth.login` à chaque connexion. |
+| `main.py` | Enregistre le routeur admin + précharge la config pipeline au démarrage. |
+| `seed_test_users.py` | + compte admin de test (`admin@test.com`). |
+
+### Modèle de données ajouté
+```text
+system_settings(id, key UNIQUE, value TEXT/JSON, updated_at, updated_by → users.id)
+activity_logs(id, timestamp, level, action, user_id → users.id, detail)
+```
+Ces tables sont créées automatiquement au démarrage (`Base.metadata.create_all`).
+
+### Paramètres du pipeline IA configurables
+| Clé | Défaut | Description |
+|---|---|---|
+| `skill_weight` | 0.50 | Poids du recouvrement des compétences |
+| `semantic_weight` | 0.20 | Poids de la similarité sémantique |
+| `experience_weight` | 0.15 | Poids de l'expérience |
+| `education_weight` | 0.10 | Poids de la formation |
+| `perfect_match_bonus` | 0.05 | Bonus match parfait |
+| `accept_threshold` | 0.80 | Score ≥ seuil → **Accepté** |
+| `review_threshold` | 0.50 | Score ≥ seuil → **À revoir**, sinon **Rejeté** |
+
+Validation : chaque valeur ∈ [0, 1] et `accept_threshold ≥ review_threshold`.
+
+---
+
+## 3. Changements — Frontend (`frontend/src/`)
+
+### Nouveaux fichiers
+| Fichier | Rôle |
+|---|---|
+| `services/admin.ts` | Client API admin (users, stats, logs, health, pipeline-config). |
+| `components/AdminGuard.tsx` | Garde côté client : redirige les non-admins. |
+| `app/admin/dashboard/page.tsx` | Statistiques globales (cartes, répartition par rôle, accès rapides). |
+| `app/admin/users/page.tsx` | Tableau CRUD utilisateurs + modale création/édition + recherche/filtre. |
+| `app/admin/monitoring/page.tsx` | Santé système, capacités IA, volumétrie, journal d'activité filtrable. |
+| `app/admin/pipeline/page.tsx` | Sliders pour les poids/seuils + validation + reset. |
+
+### Fichiers modifiés
+| Fichier | Modification |
+|---|---|
+| `components/Layout.tsx` | + navigation admin (`adminNav`) et badge « Espace Administrateur ». |
+| `app/auth/login/page.tsx` | Redirection des admins vers `/admin/dashboard` + compte admin dans l'encart de test. |
+
+---
+
+## 4. Prérequis
+
+- **Backend** : Python 3.11, dépendances de `backend/requirements.txt`.
+- **Frontend** : Node 18+, dépendances `frontend/package.json`.
+- **Base de données** : l'app lit `DATABASE_URL` depuis le `.env` **racine**.
+  Par défaut le projet pointe vers Postgres local
+  (`postgresql://...@localhost:5432/ai_talent_finder`). Sans `DATABASE_URL`,
+  fallback automatique vers SQLite (`backend/ai_talent_finder.db`).
+
+> ⚠️ **Important — base de seed ≠ base de l'app**
+> `seed_test_users.py` importe `app.core.database` directement : il **ne charge pas**
+> le `.env` racine et tombe donc sur **SQLite**. L'app (`main.py`) charge le `.env`
+> racine et utilise **Postgres**. Les deux peuvent donc viser des bases différentes.
+> Pour créer l'admin **dans la base réellement utilisée par l'app**, voir §5.1.
+
+---
+
+## 5. Comment tester
+
+### 5.1 Créer le compte administrateur (dans la base de l'app)
+
+Option A — script de seed (⚠️ vise SQLite par défaut, voir avertissement ci-dessus) :
+```bash
+cd backend
+PYTHONIOENCODING=utf-8 python seed_test_users.py
+```
+
+Option B — créer l'admin dans la base réellement utilisée par l'app (recommandé) :
+```bash
+cd backend
+PYTHONIOENCODING=utf-8 python -c "
+import sys; sys.path.insert(0,'.')
+import app.main  # charge le .env racine -> bonne DB
+from app.core.database import SessionLocal, Base, engine
+from app.models.models import User, UserRole
+from app.core.security import get_password_hash
+Base.metadata.create_all(bind=engine)
+db = SessionLocal()
+if not db.query(User).filter(User.email=='admin@test.com').first():
+    db.add(User(email='admin@test.com',
+                hashed_password=get_password_hash('password123'),
+                full_name='Admin Principal', role=UserRole.admin))
+    db.commit(); print('Admin créé')
+else:
+    print('Admin déjà présent')
+db.close()
+"
+```
+
+**Identifiants de test** : `admin@test.com` / `password123`
+
+### 5.2 Lancer l'application
+
+Backend :
+```bash
+cd backend
+uvicorn app.main:app --reload --port 8000
+```
+Frontend (autre terminal) :
+```bash
+cd frontend
+npm install   # première fois
+npm run dev
+```
+Puis ouvrir http://localhost:3000/auth/login
+
+### 5.3 Test manuel via l'interface
+
+1. Se connecter avec `admin@test.com` / `password123` → redirection vers `/admin/dashboard`.
+2. **Dashboard** : vérifier les compteurs et la répartition par rôle.
+3. **Utilisateurs** (`/admin/users`) :
+   - Créer un utilisateur (rôle au choix) → il apparaît dans la liste.
+   - Modifier son nom / rôle / mot de passe.
+   - Rechercher et filtrer par rôle.
+   - Supprimer l'utilisateur. (Auto-suppression et suppression du dernier admin sont bloquées.)
+4. **Logs & performances** (`/admin/monitoring`) : état DB, capacités IA, volumétrie, journal (filtrer par niveau).
+5. **Pipeline IA** (`/admin/pipeline`) : déplacer les sliders, **Enregistrer**, vérifier le message de succès ; tester **Réinitialiser**. Un seuil d'acceptation < seuil de revue désactive le bouton.
+6. **Contrôle d'accès** : se déconnecter, se connecter en recruteur (`bob@test.com` / `password123`) puis aller sur `/admin/dashboard` → redirection automatique hors de l'espace admin.
+
+### 5.4 Test automatisé des endpoints (backend)
+
+Test de bout en bout via `TestClient` (login, garde 403, CRUD, stats, config + validation, health, logs) :
+
+```bash
+cd backend
+PYTHONIOENCODING=utf-8 python -c "
+import sys; sys.path.insert(0,'.')
+import app.main as m
+from app.core.database import SessionLocal, Base, engine
+from app.models.models import User, UserRole
+from app.core.security import get_password_hash
+Base.metadata.create_all(bind=engine)
+db = SessionLocal()
+if not db.query(User).filter(User.email=='admin@test.com').first():
+    db.add(User(email='admin@test.com', hashed_password=get_password_hash('password123'),
+                full_name='Admin', role=UserRole.admin)); db.commit()
+db.close()
+from fastapi.testclient import TestClient
+with TestClient(m.app) as c:
+    h = {'Authorization': 'Bearer ' + c.post('/api/auth/login', json={'email':'admin@test.com','password':'password123'}).json()['access_token']}
+    # garde de rôle (recruteur -> 403)
+    rec = c.post('/api/auth/login', json={'email':'bob@test.com','password':'password123'})
+    if rec.status_code == 200:
+        h2 = {'Authorization':'Bearer '+rec.json()['access_token']}
+        assert c.get('/api/admin/stats', headers=h2).status_code == 403
+    assert c.get('/api/admin/stats', headers=h).status_code == 200
+    u = c.post('/api/admin/users', headers=h, json={'email':'tmp_x@test.com','password':'secret123','full_name':'Tmp','role':'recruiter'})
+    assert u.status_code == 201; uid = u.json()['id']
+    assert c.patch(f'/api/admin/users/{uid}', headers=h, json={'role':'candidate'}).json()['role'] == 'candidate'
+    assert c.put('/api/admin/pipeline-config', headers=h, json={'accept_threshold':0.9,'review_threshold':0.4}).status_code == 200
+    assert c.put('/api/admin/pipeline-config', headers=h, json={'accept_threshold':0.3,'review_threshold':0.5}).status_code == 422  # invalide
+    assert c.post('/api/admin/pipeline-config/reset', headers=h).status_code == 200
+    assert c.get('/api/admin/health', headers=h).json()['status'] == 'ok'
+    assert c.delete(f'/api/admin/users/{uid}', headers=h).status_code == 204
+    print('OK — tous les endpoints admin passent')
+"
+```
+
+### 5.5 Test via cURL (serveur lancé sur :8000)
+
+```bash
+# 1) Login admin -> récupérer le token
+TOKEN=$(curl -s -X POST http://localhost:8000/api/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"email":"admin@test.com","password":"password123"}' | python -c "import sys,json;print(json.load(sys.stdin)['access_token'])")
+
+# 2) Statistiques globales
+curl -s http://localhost:8000/api/admin/stats -H "Authorization: Bearer $TOKEN"
+
+# 3) Liste des utilisateurs
+curl -s http://localhost:8000/api/admin/users -H "Authorization: Bearer $TOKEN"
+
+# 4) Config du pipeline IA
+curl -s http://localhost:8000/api/admin/pipeline-config -H "Authorization: Bearer $TOKEN"
+
+# 5) Mettre à jour un poids/seuil
+curl -s -X PUT http://localhost:8000/api/admin/pipeline-config \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"semantic_weight":0.25}'
+
+# 6) Logs & santé
+curl -s http://localhost:8000/api/admin/logs   -H "Authorization: Bearer $TOKEN"
+curl -s http://localhost:8000/api/admin/health -H "Authorization: Bearer $TOKEN"
+```
+
+Doc interactive (Swagger) : http://localhost:8000/docs (section **admin**).
+
+### 5.6 Non-régression du scoring (les défauts ne changent rien)
+
+```bash
+cd backend
+PYTHONIOENCODING=utf-8 python -c "
+import sys; sys.path.insert(0,'.')
+from app.services.scoring import decide_match, MatchDecision
+assert decide_match(0.85) == MatchDecision.ACCEPTED
+assert decide_match(0.60) == MatchDecision.REVIEW
+assert decide_match(0.30) == MatchDecision.REJECTED
+print('OK — seuils par défaut préservés')
+"
+```
+
+### 5.7 Vérifications frontend (qualité)
+
+```bash
+cd frontend
+npx tsc --noEmit                       # typage : aucune erreur attendue
+npx eslint src/app/admin src/components/AdminGuard.tsx src/services/admin.ts
+npm run build                          # build de production
+```
+
+---
+
+## 6. Résultats de vérification (déjà exécutés)
+
+- ✅ Endpoints admin testés de bout en bout sur la base Postgres réelle :
+  login (200), garde de rôle (403), CRUD users, stats, pipeline-config (PUT + validation 422 + reset), health, logs.
+- ✅ Scoring : comportement par défaut **inchangé** (poids 50/20/15/10, seuils 0.8/0.5).
+- ✅ Frontend : `tsc --noEmit` et ESLint sans erreur.
+
+---
+
+## 7. Récapitulatif des fichiers
+
+```
+backend/app/
+├── api/admin.py                 (nouveau)
+├── api/auth.py                  (modifié : log auth.login)
+├── core/dependencies.py         (modifié : require_admin, log_activity)
+├── core/settings_store.py       (nouveau)
+├── main.py                      (modifié : routeur admin + preload config)
+├── models/models.py             (modifié : SystemSetting, ActivityLog)
+├── schemas/admin.py             (nouveau)
+└── services/scoring.py          (modifié : poids/seuils configurables)
+backend/seed_test_users.py       (modifié : compte admin)
+
+frontend/src/
+├── app/admin/dashboard/page.tsx     (nouveau)
+├── app/admin/users/page.tsx         (nouveau)
+├── app/admin/monitoring/page.tsx    (nouveau)
+├── app/admin/pipeline/page.tsx      (nouveau)
+├── app/auth/login/page.tsx          (modifié : redirection admin)
+├── components/AdminGuard.tsx        (nouveau)
+├── components/Layout.tsx            (modifié : nav + badge admin)
+└── services/admin.ts                (nouveau)
+```

--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -14,6 +14,7 @@ from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, status, Query
 from sqlalchemy import func
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.core.dependencies import get_db, get_current_user, require_admin, log_activity
@@ -27,6 +28,7 @@ from app.models.models import (
     RecruiterFeedback,
     Skill,
     ActivityLog,
+    SystemSetting,
 )
 from app.schemas.admin import (
     AdminUserCreate,
@@ -150,8 +152,27 @@ def delete_user(
         _assert_not_last_admin(db, user.id)
 
     email = user.email
-    db.delete(user)
-    db.commit()
+
+    # Detach audit references so deletion is not blocked by their FK. These are
+    # metadata only (safe to null). Done explicitly because pre-existing
+    # databases may carry the FK without ON DELETE SET NULL.
+    db.query(ActivityLog).filter(ActivityLog.user_id == user.id).update(
+        {ActivityLog.user_id: None}, synchronize_session=False
+    )
+    db.query(SystemSetting).filter(SystemSetting.updated_by == user.id).update(
+        {SystemSetting.updated_by: None}, synchronize_session=False
+    )
+
+    try:
+        db.delete(user)
+        db.commit()
+    except IntegrityError:
+        # User still owns domain data (offres, favoris, feedback, profil candidat…).
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Impossible de supprimer: cet utilisateur possède des données liées (offres, favoris, feedback ou profil). Supprimez-les d'abord.",
+        )
 
     log_activity(db, "user.delete", user_id=admin.id, detail=f"Suppression de {email}")
     return None

--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -1,0 +1,306 @@
+"""Admin API endpoints — implements the Administrateur use cases.
+
+Use cases (from the PFA use-case diagram, package "Administrateur"):
+  * Gérer les utilisateurs (CRUD)            -> /api/admin/users ...
+  * Consulter les statistiques globales      -> /api/admin/stats
+  * Superviser les logs et performances      -> /api/admin/health, /api/admin/logs
+  * Configurer les paramètres du pipeline IA -> /api/admin/pipeline-config
+
+All routes require an authenticated user with the ``admin`` role.
+"""
+
+from datetime import datetime, timedelta
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, status, Query
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from app.core.dependencies import get_db, get_current_user, require_admin, log_activity
+from app.core.security import get_password_hash
+from app.models.models import (
+    User,
+    UserRole,
+    Candidate,
+    JobCriteria,
+    MatchResult,
+    RecruiterFeedback,
+    Skill,
+    ActivityLog,
+)
+from app.schemas.admin import (
+    AdminUserCreate,
+    AdminUserUpdate,
+    AdminUserResponse,
+    GlobalStatsResponse,
+    ActivityLogResponse,
+    SystemHealthResponse,
+    PipelineConfigResponse,
+    PipelineConfigUpdate,
+)
+from app.core import settings_store
+
+
+router = APIRouter(
+    prefix="/api/admin",
+    tags=["admin"],
+    dependencies=[Depends(require_admin)],
+)
+
+
+# ===========================================================================
+# Gérer les utilisateurs (CRUD)
+# ===========================================================================
+
+@router.get("/users", response_model=List[AdminUserResponse])
+def list_users(
+    role: Optional[UserRole] = Query(None, description="Filtrer par rôle"),
+    search: Optional[str] = Query(None, description="Recherche email / nom"),
+    skip: int = 0,
+    limit: int = 100,
+    db: Session = Depends(get_db),
+):
+    """List all users (optionally filtered by role or a search term)."""
+    query = db.query(User)
+    if role is not None:
+        query = query.filter(User.role == role)
+    if search:
+        like = f"%{search.lower()}%"
+        query = query.filter(
+            func.lower(User.email).like(like) | func.lower(User.full_name).like(like)
+        )
+    return query.order_by(User.created_at.desc()).offset(skip).limit(limit).all()
+
+
+@router.post("/users", response_model=AdminUserResponse, status_code=status.HTTP_201_CREATED)
+def create_user(
+    payload: AdminUserCreate,
+    db: Session = Depends(get_db),
+    admin: User = Depends(get_current_user),
+):
+    """Create a new user with any role."""
+    existing = db.query(User).filter(User.email == payload.email).first()
+    if existing:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Email déjà utilisé")
+
+    user = User(
+        email=payload.email,
+        hashed_password=get_password_hash(payload.password),
+        full_name=payload.full_name,
+        role=UserRole(payload.role.value),
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+
+    log_activity(db, "user.create", user_id=admin.id, detail=f"Création de {user.email} ({user.role.value})")
+    return user
+
+
+@router.get("/users/{user_id}", response_model=AdminUserResponse)
+def get_user(user_id: int, db: Session = Depends(get_db)):
+    user = db.query(User).filter(User.id == user_id).first()
+    if not user:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Utilisateur introuvable")
+    return user
+
+
+@router.patch("/users/{user_id}", response_model=AdminUserResponse)
+def update_user(
+    user_id: int,
+    payload: AdminUserUpdate,
+    db: Session = Depends(get_db),
+    admin: User = Depends(get_current_user),
+):
+    """Update a user's name, role and/or password."""
+    user = db.query(User).filter(User.id == user_id).first()
+    if not user:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Utilisateur introuvable")
+
+    if payload.full_name is not None:
+        user.full_name = payload.full_name
+    if payload.role is not None:
+        # Guard: prevent removing the last admin.
+        if user.role == UserRole.admin and payload.role != UserRole.admin:
+            _assert_not_last_admin(db, user.id)
+        user.role = UserRole(payload.role.value)
+    if payload.password is not None:
+        user.hashed_password = get_password_hash(payload.password)
+
+    db.commit()
+    db.refresh(user)
+
+    log_activity(db, "user.update", user_id=admin.id, detail=f"Mise à jour de {user.email}")
+    return user
+
+
+@router.delete("/users/{user_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_user(
+    user_id: int,
+    db: Session = Depends(get_db),
+    admin: User = Depends(get_current_user),
+):
+    """Delete a user. An admin cannot delete themselves or the last admin."""
+    user = db.query(User).filter(User.id == user_id).first()
+    if not user:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Utilisateur introuvable")
+    if user.id == admin.id:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Vous ne pouvez pas supprimer votre propre compte")
+    if user.role == UserRole.admin:
+        _assert_not_last_admin(db, user.id)
+
+    email = user.email
+    db.delete(user)
+    db.commit()
+
+    log_activity(db, "user.delete", user_id=admin.id, detail=f"Suppression de {email}")
+    return None
+
+
+def _assert_not_last_admin(db: Session, excluded_user_id: int) -> None:
+    remaining_admins = (
+        db.query(func.count(User.id))
+        .filter(User.role == UserRole.admin, User.id != excluded_user_id)
+        .scalar()
+    )
+    if not remaining_admins:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Impossible: au moins un administrateur doit subsister",
+        )
+
+
+# ===========================================================================
+# Consulter les statistiques globales
+# ===========================================================================
+
+@router.get("/stats", response_model=GlobalStatsResponse)
+def global_stats(db: Session = Depends(get_db)):
+    """Aggregate platform-wide statistics for the admin dashboard."""
+    role_rows = (
+        db.query(User.role, func.count(User.id)).group_by(User.role).all()
+    )
+    users_by_role = {role.value if hasattr(role, "value") else str(role): count for role, count in role_rows}
+    total_users = sum(users_by_role.values())
+
+    avg_score = db.query(func.avg(MatchResult.score)).scalar()
+    week_ago = datetime.utcnow() - timedelta(days=7)
+    recent_signups = db.query(func.count(User.id)).filter(User.created_at >= week_ago).scalar() or 0
+
+    return GlobalStatsResponse(
+        total_users=total_users,
+        users_by_role=users_by_role,
+        total_candidates=db.query(func.count(Candidate.id)).scalar() or 0,
+        total_jobs=db.query(func.count(JobCriteria.id)).scalar() or 0,
+        total_match_results=db.query(func.count(MatchResult.id)).scalar() or 0,
+        total_feedback=db.query(func.count(RecruiterFeedback.id)).scalar() or 0,
+        total_skills=db.query(func.count(Skill.id)).scalar() or 0,
+        average_match_score=round(float(avg_score), 4) if avg_score is not None else None,
+        recent_signups=recent_signups,
+    )
+
+
+# ===========================================================================
+# Superviser les logs et performances
+# ===========================================================================
+
+@router.get("/logs", response_model=List[ActivityLogResponse])
+def list_logs(
+    level: Optional[str] = Query(None, description="INFO | WARNING | ERROR"),
+    action: Optional[str] = Query(None, description="Filtrer par préfixe d'action"),
+    limit: int = Query(100, le=500),
+    db: Session = Depends(get_db),
+):
+    """Return the most recent activity-log entries."""
+    query = db.query(ActivityLog)
+    if level:
+        query = query.filter(ActivityLog.level == level.upper())
+    if action:
+        query = query.filter(ActivityLog.action.like(f"{action}%"))
+    return query.order_by(ActivityLog.timestamp.desc()).limit(limit).all()
+
+
+@router.get("/health", response_model=SystemHealthResponse)
+def system_health(db: Session = Depends(get_db)):
+    """System health snapshot: DB connectivity, capabilities and counts."""
+    database_connected = True
+    try:
+        db.query(func.count(User.id)).scalar()
+    except Exception:
+        database_connected = False
+
+    try:
+        from app.core.capabilities import get_capabilities
+        capabilities = get_capabilities()
+    except Exception:
+        capabilities = {}
+
+    counts = {
+        "users": db.query(func.count(User.id)).scalar() or 0,
+        "candidates": db.query(func.count(Candidate.id)).scalar() or 0,
+        "jobs": db.query(func.count(JobCriteria.id)).scalar() or 0,
+        "match_results": db.query(func.count(MatchResult.id)).scalar() or 0,
+        "logs": db.query(func.count(ActivityLog.id)).scalar() or 0,
+    }
+
+    level_rows = (
+        db.query(ActivityLog.level, func.count(ActivityLog.id))
+        .group_by(ActivityLog.level)
+        .all()
+    )
+    log_levels = {level: count for level, count in level_rows}
+
+    return SystemHealthResponse(
+        status="ok" if database_connected else "degraded",
+        database_connected=database_connected,
+        capabilities=capabilities,
+        counts=counts,
+        log_levels=log_levels,
+    )
+
+
+# ===========================================================================
+# Configurer les paramètres du pipeline IA
+# ===========================================================================
+
+def _pipeline_config_response() -> PipelineConfigResponse:
+    cfg = settings_store.get_runtime_pipeline_config()
+    return PipelineConfigResponse(defaults=settings_store.DEFAULT_PIPELINE_CONFIG, **cfg)
+
+
+@router.get("/pipeline-config", response_model=PipelineConfigResponse)
+def get_pipeline_config(db: Session = Depends(get_db)):
+    """Return the current AI matching pipeline parameters."""
+    settings_store.load_pipeline_config(db)
+    return _pipeline_config_response()
+
+
+@router.put("/pipeline-config", response_model=PipelineConfigResponse)
+def update_pipeline_config(
+    payload: PipelineConfigUpdate,
+    db: Session = Depends(get_db),
+    admin: User = Depends(get_current_user),
+):
+    """Update one or more pipeline parameters (weights / thresholds)."""
+    partial = {k: v for k, v in payload.model_dump().items() if v is not None}
+    if not partial:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Aucun paramètre fourni")
+
+    errors = settings_store.validate_pipeline_config(partial)
+    if errors:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=errors)
+
+    settings_store.update_pipeline_config(db, partial, updated_by=admin.id)
+    log_activity(db, "pipeline.config.update", user_id=admin.id, detail=str(partial))
+    return _pipeline_config_response()
+
+
+@router.post("/pipeline-config/reset", response_model=PipelineConfigResponse)
+def reset_pipeline_config(
+    db: Session = Depends(get_db),
+    admin: User = Depends(get_current_user),
+):
+    """Reset pipeline parameters back to their default values."""
+    settings_store.reset_pipeline_config(db, updated_by=admin.id)
+    log_activity(db, "pipeline.config.reset", user_id=admin.id, detail="Réinitialisation des paramètres")
+    return _pipeline_config_response()

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -15,7 +15,7 @@ from app.core.security import (
     decode_token,
     ACCESS_TOKEN_EXPIRE_MINUTES,
 )
-from app.core.dependencies import get_db, get_current_user
+from app.core.dependencies import get_db, get_current_user, log_activity
 from app.schemas.user import UserCreate, UserLogin, UserResponse, Token, TokenData
 from app.models.models import User, UserRole as DBUserRole
 
@@ -115,7 +115,9 @@ async def login(user_login: UserLogin, db: Session = Depends(get_db)) -> Token:
     access_token = create_access_token(
         data={"sub": db_user.email, "user_id": db_user.id}
     )
-    
+
+    log_activity(db, "auth.login", user_id=db_user.id, detail=f"Connexion de {db_user.email}")
+
     # 4. Return token + user
     return Token(
         access_token=access_token,

--- a/backend/app/core/dependencies.py
+++ b/backend/app/core/dependencies.py
@@ -4,7 +4,7 @@ from sqlalchemy.orm import Session
 from .database import SessionLocal
 from .security import decode_token
 from app.schemas.user import TokenData
-from app.models.models import User
+from app.models.models import User, UserRole
 
 
 def get_db() -> Generator[Session, None, None]:
@@ -90,5 +90,44 @@ def get_current_user(
             detail="User not found in database",
             headers={"WWW-Authenticate": "Bearer"},
         )
-    
+
     return user
+
+
+def require_admin(current_user: User = Depends(get_current_user)) -> User:
+    """Dependency guard for admin-only routes.
+
+    Use in admin endpoints/routers:
+        @router.get("/users", dependencies=[Depends(require_admin)])
+
+    Raises:
+        HTTPException 403 if the authenticated user is not an administrator.
+    """
+    if current_user.role != UserRole.admin:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Accès réservé aux administrateurs",
+        )
+    return current_user
+
+
+def log_activity(
+    db: Session,
+    action: str,
+    *,
+    user_id: Optional[int] = None,
+    detail: Optional[str] = None,
+    level: str = "INFO",
+) -> None:
+    """Best-effort audit logging used by the admin monitoring view.
+
+    Never raises: a logging failure must not break the originating request.
+    """
+    try:
+        from app.models.models import ActivityLog
+
+        entry = ActivityLog(action=action, user_id=user_id, detail=detail, level=level)
+        db.add(entry)
+        db.commit()
+    except Exception:
+        db.rollback()

--- a/backend/app/core/settings_store.py
+++ b/backend/app/core/settings_store.py
@@ -1,0 +1,128 @@
+"""Runtime configuration store for the AI matching pipeline.
+
+Backs the admin use case "Configurer les paramètres du pipeline IA". The
+configuration is persisted in the ``system_settings`` table (key/value, JSON
+encoded) and mirrored in a module-level cache so the hot scoring path does not
+hit the database on every call.
+
+Reads always succeed even without a database: if nothing has been configured,
+the built-in defaults (identical to the historical hard-coded values) are used,
+so existing behaviour is unchanged until an admin overrides a parameter.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Dict
+
+logger = logging.getLogger(__name__)
+
+PIPELINE_CONFIG_KEY = "pipeline_config"
+
+# Defaults mirror the original hard-coded weights/thresholds in
+# app/services/scoring.py so default behaviour is preserved.
+DEFAULT_PIPELINE_CONFIG: Dict[str, float] = {
+    "skill_weight": 0.50,
+    "semantic_weight": 0.20,
+    "experience_weight": 0.15,
+    "education_weight": 0.10,
+    "perfect_match_bonus": 0.05,
+    "accept_threshold": 0.80,
+    "review_threshold": 0.50,
+}
+
+# Bounds used to validate incoming admin updates.
+_WEIGHT_KEYS = {
+    "skill_weight",
+    "semantic_weight",
+    "experience_weight",
+    "education_weight",
+    "perfect_match_bonus",
+}
+_THRESHOLD_KEYS = {"accept_threshold", "review_threshold"}
+
+# Module-level cache. Populated lazily / on startup; defaults until then.
+_runtime_config: Dict[str, float] = dict(DEFAULT_PIPELINE_CONFIG)
+_loaded_from_db = False
+
+
+def get_runtime_pipeline_config() -> Dict[str, float]:
+    """Return the current pipeline config from the in-memory cache (no DB hit)."""
+    return dict(_runtime_config)
+
+
+def load_pipeline_config(db) -> Dict[str, float]:
+    """Load config from the database into the cache, merging over defaults."""
+    global _runtime_config, _loaded_from_db
+    try:
+        from app.models.models import SystemSetting
+
+        row = (
+            db.query(SystemSetting)
+            .filter(SystemSetting.key == PIPELINE_CONFIG_KEY)
+            .first()
+        )
+        merged = dict(DEFAULT_PIPELINE_CONFIG)
+        if row and row.value:
+            stored = json.loads(row.value)
+            merged.update({k: v for k, v in stored.items() if k in DEFAULT_PIPELINE_CONFIG})
+        _runtime_config = merged
+        _loaded_from_db = True
+    except Exception as exc:  # pragma: no cover - best effort
+        logger.warning("Could not load pipeline config from DB: %s", exc)
+    return dict(_runtime_config)
+
+
+def validate_pipeline_config(partial: Dict[str, float]) -> Dict[str, str]:
+    """Validate a partial config update. Returns a dict of field -> error message."""
+    errors: Dict[str, str] = {}
+    for key, value in partial.items():
+        if key not in DEFAULT_PIPELINE_CONFIG:
+            errors[key] = "Paramètre inconnu"
+            continue
+        try:
+            value = float(value)
+        except (TypeError, ValueError):
+            errors[key] = "Doit être un nombre"
+            continue
+        if not (0.0 <= value <= 1.0):
+            errors[key] = "Doit être compris entre 0 et 1"
+
+    # Cross-field rule: thresholds must keep accept >= review.
+    merged = {**_runtime_config, **{k: float(v) for k, v in partial.items() if k in DEFAULT_PIPELINE_CONFIG}}
+    if merged["accept_threshold"] < merged["review_threshold"]:
+        errors["accept_threshold"] = "Le seuil d'acceptation doit être >= au seuil de revue"
+    return errors
+
+
+def update_pipeline_config(db, partial: Dict[str, float], updated_by: int | None = None) -> Dict[str, float]:
+    """Persist a partial config update and refresh the cache.
+
+    Caller is responsible for having validated ``partial`` first.
+    """
+    global _runtime_config
+    from app.models.models import SystemSetting
+
+    merged = dict(_runtime_config)
+    merged.update({k: float(v) for k, v in partial.items() if k in DEFAULT_PIPELINE_CONFIG})
+
+    row = (
+        db.query(SystemSetting)
+        .filter(SystemSetting.key == PIPELINE_CONFIG_KEY)
+        .first()
+    )
+    if row is None:
+        row = SystemSetting(key=PIPELINE_CONFIG_KEY)
+        db.add(row)
+    row.value = json.dumps(merged)
+    row.updated_by = updated_by
+    db.commit()
+
+    _runtime_config = merged
+    return dict(_runtime_config)
+
+
+def reset_pipeline_config(db, updated_by: int | None = None) -> Dict[str, float]:
+    """Reset config back to defaults (persisted)."""
+    return update_pipeline_config(db, dict(DEFAULT_PIPELINE_CONFIG), updated_by=updated_by)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -82,9 +82,22 @@ def on_startup():
     capabilities = log_capabilities_summary()
     assert_required_features(capabilities)
 
+    # Load admin-configurable AI pipeline parameters into the runtime cache.
+    try:
+        from app.core.database import SessionLocal
+        from app.core.settings_store import load_pipeline_config
+        _db = SessionLocal()
+        try:
+            load_pipeline_config(_db)
+        finally:
+            _db.close()
+    except Exception as e:
+        logging.warning("Could not preload pipeline config: %s", e)
+
     # Conditionally include API routers. If a router import fails (e.g. heavy
     # ML dependencies missing), the app still starts and exposes /health.
     include_optional_router("app.api.auth")
+    include_optional_router("app.api.admin")
     include_optional_router("app.api.candidates")
     include_optional_router("app.api.skills")
     include_optional_router("app.api.jobs")

--- a/backend/app/models/models.py
+++ b/backend/app/models/models.py
@@ -185,6 +185,39 @@ class Favorite(Base):
     candidate = relationship("Candidate", back_populates="favorites")
 
 
+class SystemSetting(Base):
+    """Admin use case: 'Configurer les paramètres du pipeline IA'.
+
+    Key/value store (value is JSON-encoded) for runtime configuration such as
+    the matching pipeline weights and decision thresholds.
+    """
+    __tablename__ = "system_settings"
+
+    id = Column(Integer, primary_key=True, index=True)
+    key = Column(String, unique=True, index=True, nullable=False)
+    value = Column(Text, nullable=True)  # JSON-encoded payload
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False)
+    updated_by = Column(Integer, ForeignKey("users.id"), nullable=True)
+
+
+class ActivityLog(Base):
+    """Admin use case: 'Superviser les logs et performances'.
+
+    Lightweight audit trail of meaningful actions (auth, user management,
+    configuration changes) used to power the admin monitoring view.
+    """
+    __tablename__ = "activity_logs"
+
+    id = Column(Integer, primary_key=True, index=True)
+    timestamp = Column(DateTime, default=datetime.utcnow, nullable=False, index=True)
+    level = Column(String, default="INFO", nullable=False)  # INFO | WARNING | ERROR
+    action = Column(String, nullable=False, index=True)  # e.g. "user.create", "auth.login"
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=True)
+    detail = Column(Text, nullable=True)
+
+    user = relationship("User", foreign_keys=[user_id])
+
+
 class RecruiterFeedback(Base):
     """Phase 3: Capture recruiter decisions vs model predictions for continuous learning."""
     __tablename__ = "recruiter_feedback"

--- a/backend/app/models/models.py
+++ b/backend/app/models/models.py
@@ -197,7 +197,7 @@ class SystemSetting(Base):
     key = Column(String, unique=True, index=True, nullable=False)
     value = Column(Text, nullable=True)  # JSON-encoded payload
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False)
-    updated_by = Column(Integer, ForeignKey("users.id"), nullable=True)
+    updated_by = Column(Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
 
 
 class ActivityLog(Base):
@@ -212,7 +212,7 @@ class ActivityLog(Base):
     timestamp = Column(DateTime, default=datetime.utcnow, nullable=False, index=True)
     level = Column(String, default="INFO", nullable=False)  # INFO | WARNING | ERROR
     action = Column(String, nullable=False, index=True)  # e.g. "user.create", "auth.login"
-    user_id = Column(Integer, ForeignKey("users.id"), nullable=True)
+    user_id = Column(Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
     detail = Column(Text, nullable=True)
 
     user = relationship("User", foreign_keys=[user_id])

--- a/backend/app/schemas/admin.py
+++ b/backend/app/schemas/admin.py
@@ -1,0 +1,109 @@
+"""Pydantic schemas for the admin module.
+
+Covers the Administrateur use cases:
+- Gérer les utilisateurs (CRUD)
+- Consulter les statistiques globales
+- Superviser les logs et performances
+- Configurer les paramètres du pipeline IA
+"""
+
+from pydantic import BaseModel, EmailStr, Field
+from typing import Optional, Dict, List
+from datetime import datetime
+
+from app.schemas.user import UserRole
+
+
+# ---------------------------------------------------------------------------
+# Gérer les utilisateurs (CRUD)
+# ---------------------------------------------------------------------------
+
+class AdminUserCreate(BaseModel):
+    email: EmailStr
+    password: str = Field(..., min_length=6)
+    full_name: str = Field(..., min_length=2)
+    role: UserRole = UserRole.recruiter
+
+
+class AdminUserUpdate(BaseModel):
+    """All fields optional; only provided fields are updated."""
+    full_name: Optional[str] = Field(None, min_length=2)
+    role: Optional[UserRole] = None
+    password: Optional[str] = Field(None, min_length=6)
+
+
+class AdminUserResponse(BaseModel):
+    id: int
+    email: str
+    full_name: str
+    role: UserRole
+    created_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+# ---------------------------------------------------------------------------
+# Consulter les statistiques globales
+# ---------------------------------------------------------------------------
+
+class GlobalStatsResponse(BaseModel):
+    total_users: int
+    users_by_role: Dict[str, int]
+    total_candidates: int
+    total_jobs: int
+    total_match_results: int
+    total_feedback: int
+    total_skills: int
+    average_match_score: Optional[float] = None
+    recent_signups: int  # users created in the last 7 days
+
+
+# ---------------------------------------------------------------------------
+# Superviser les logs et performances
+# ---------------------------------------------------------------------------
+
+class ActivityLogResponse(BaseModel):
+    id: int
+    timestamp: datetime
+    level: str
+    action: str
+    user_id: Optional[int] = None
+    detail: Optional[str] = None
+
+    class Config:
+        from_attributes = True
+
+
+class SystemHealthResponse(BaseModel):
+    status: str
+    database_connected: bool
+    capabilities: Dict[str, object]
+    counts: Dict[str, int]
+    log_levels: Dict[str, int]  # number of log entries by level
+
+
+# ---------------------------------------------------------------------------
+# Configurer les paramètres du pipeline IA
+# ---------------------------------------------------------------------------
+
+class PipelineConfigResponse(BaseModel):
+    skill_weight: float
+    semantic_weight: float
+    experience_weight: float
+    education_weight: float
+    perfect_match_bonus: float
+    accept_threshold: float
+    review_threshold: float
+    defaults: Dict[str, float]
+
+
+class PipelineConfigUpdate(BaseModel):
+    """Partial update; only provided fields change. Each value in [0, 1]."""
+    skill_weight: Optional[float] = Field(None, ge=0, le=1)
+    semantic_weight: Optional[float] = Field(None, ge=0, le=1)
+    experience_weight: Optional[float] = Field(None, ge=0, le=1)
+    education_weight: Optional[float] = Field(None, ge=0, le=1)
+    perfect_match_bonus: Optional[float] = Field(None, ge=0, le=1)
+    accept_threshold: Optional[float] = Field(None, ge=0, le=1)
+    review_threshold: Optional[float] = Field(None, ge=0, le=1)

--- a/backend/app/services/scoring.py
+++ b/backend/app/services/scoring.py
@@ -1,13 +1,22 @@
-"""Scoring and decision logic with calibrated business rules."""
+"""Scoring and decision logic with calibrated business rules.
+
+Weights and decision thresholds default to the calibrated values below but can
+be overridden at runtime by an administrator through the admin settings
+("Configurer les paramètres du pipeline IA"). The current values are read from
+``app.core.settings_store`` which falls back to these defaults when nothing has
+been configured.
+"""
 
 from typing import Dict, Any, List, Tuple
 from enum import Enum
 
+from app.core.settings_store import get_runtime_pipeline_config
+
 
 class MatchDecision(str, Enum):
-    ACCEPTED = "accepted"  # Score >= 0.8
-    REVIEW = "to_review"    # 0.5 <= Score < 0.8
-    REJECTED = "rejected"   # Score < 0.5
+    ACCEPTED = "accepted"  # Score >= accept_threshold (default 0.8)
+    REVIEW = "to_review"    # review_threshold <= Score < accept_threshold
+    REJECTED = "rejected"   # Score < review_threshold (default 0.5)
 
 
 def compute_match_score(
@@ -28,55 +37,63 @@ def compute_match_score(
     - Education: 10%
     - Bonus: 5% for perfect match
     """
+    cfg = get_runtime_pipeline_config()
+    w_skill = cfg["skill_weight"]
+    w_semantic = cfg["semantic_weight"]
+    w_exp = cfg["experience_weight"]
+    w_edu = cfg["education_weight"]
+    bonus = cfg["perfect_match_bonus"]
+
     score = 0.0
 
-    # Skill matching (weight: 50%)
+    # Skill matching
     if job_skills:
         required_set = set(s.lower() for s in job_skills)
         cv_set = set(s.lower() for s in cv_skills)
         intersection = required_set & cv_set
         skill_score = len(intersection) / len(required_set) if intersection else 0.0
-        score += skill_score * 0.50
+        score += skill_score * w_skill
     else:
-        score += 0.50  # no skills required
+        score += w_skill  # no skills required
 
-    # Semantic similarity (weight: 20%)
-    score += (similarity_score or 0.0) * 0.20
+    # Semantic similarity
+    score += (similarity_score or 0.0) * w_semantic
 
-    # Experience match (weight: 15%)
+    # Experience match
     if job_years > 0:
         if cv_years >= job_years:
-            score += 0.15
+            score += w_exp
         else:
-            # Linear penalty: each missing year = 15% / job_years penalty
+            # Linear penalty: each missing year reduces the experience weight
             penalty = (job_years - cv_years) / job_years
-            score += max(0, 0.15 * (1 - penalty))
+            score += max(0, w_exp * (1 - penalty))
     else:
-        score += 0.15
+        score += w_exp
 
-    # Education match (weight: 10%)
+    # Education match
     if job_edu_level > 0:
         if cv_edu_level >= job_edu_level:
-            score += 0.10
+            score += w_edu
         else:
             # Penalty proportional to gap
             penalty = (job_edu_level - cv_edu_level) / job_edu_level
-            score += max(0, 0.10 * (1 - penalty))
+            score += max(0, w_edu * (1 - penalty))
     else:
-        score += 0.10
+        score += w_edu
 
-    # Bonus for perfect skill + experience match (up to 5%)
+    # Bonus for perfect skill + experience match
     if job_skills and cv_years >= job_years and len(intersection) == len(required_set):
-        score += 0.05
+        score += bonus
 
     return min(1.0, max(0.0, score))
 
 
 def decide_match(score: float) -> MatchDecision:
-    """Map score to decision."""
-    if score >= 0.80:
+    """Map score to decision using the configured thresholds."""
+    cfg = get_runtime_pipeline_config()
+    if score >= cfg["accept_threshold"]:
         return MatchDecision.ACCEPTED
-    elif score >= 0.50:
+    elif score >= cfg["review_threshold"]:
         return MatchDecision.REVIEW
     else:
         return MatchDecision.REJECTED

--- a/backend/seed_test_users.py
+++ b/backend/seed_test_users.py
@@ -37,6 +37,12 @@ def seed_users():
             "password": "pass123",
             "full_name": "Alice Example",
             "role": UserRole.candidate
+        },
+        {
+            "email": "admin@test.com",
+            "password": "password123",
+            "full_name": "Admin Principal",
+            "role": UserRole.admin
         }
     ]
     

--- a/frontend/src/app/admin/dashboard/page.tsx
+++ b/frontend/src/app/admin/dashboard/page.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import {
+  Users, FileText, GitCompareArrows, MessageSquare, Wrench, TrendingUp,
+  ShieldCheck, Activity, SlidersVertical,
+} from "lucide-react";
+import Layout from "@/components/Layout";
+import AdminGuard from "@/components/AdminGuard";
+import { adminApi, type GlobalStats } from "@/services/admin";
+import { getErrorMessage } from "@/utils/errorHandler";
+
+const roleLabels: Record<string, string> = {
+  admin: "Administrateurs",
+  recruiter: "Recruteurs",
+  candidate: "Candidats",
+};
+
+function StatCard({ icon: Icon, label, value, accent }: {
+  icon: React.ElementType; label: string; value: string | number; accent: string;
+}) {
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+      <div className="flex items-center justify-between">
+        <p className="text-sm font-medium text-gray-500">{label}</p>
+        <span className={`flex h-9 w-9 items-center justify-center rounded-lg ${accent}`}>
+          <Icon className="h-5 w-5" />
+        </span>
+      </div>
+      <p className="mt-3 text-3xl font-bold text-gray-900">{value}</p>
+    </div>
+  );
+}
+
+export default function AdminDashboardPage() {
+  const [stats, setStats] = useState<GlobalStats | null>(null);
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    adminApi
+      .getStats()
+      .then((res) => setStats(res.data))
+      .catch((err) => setError(getErrorMessage(err)))
+      .finally(() => setLoading(false));
+  }, []);
+
+  return (
+    <AdminGuard>
+      <Layout>
+        <div className="mb-8 flex items-center gap-3">
+          <span className="flex h-11 w-11 items-center justify-center rounded-xl bg-rose-100 text-rose-600">
+            <ShieldCheck className="h-6 w-6" />
+          </span>
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900">Tableau de bord administrateur</h1>
+            <p className="text-gray-600">Statistiques globales de la plateforme</p>
+          </div>
+        </div>
+
+        {error && (
+          <div className="mb-6 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">{error}</div>
+        )}
+
+        {loading ? (
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            {Array.from({ length: 8 }).map((_, i) => (
+              <div key={i} className="h-28 animate-pulse rounded-xl bg-gray-100" />
+            ))}
+          </div>
+        ) : stats ? (
+          <>
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+              <StatCard icon={Users} label="Utilisateurs" value={stats.total_users} accent="bg-indigo-100 text-indigo-600" />
+              <StatCard icon={FileText} label="Candidats" value={stats.total_candidates} accent="bg-emerald-100 text-emerald-600" />
+              <StatCard icon={GitCompareArrows} label="Offres / Critères" value={stats.total_jobs} accent="bg-blue-100 text-blue-600" />
+              <StatCard icon={Activity} label="Résultats de matching" value={stats.total_match_results} accent="bg-amber-100 text-amber-600" />
+              <StatCard icon={MessageSquare} label="Feedbacks recruteurs" value={stats.total_feedback} accent="bg-fuchsia-100 text-fuchsia-600" />
+              <StatCard icon={Wrench} label="Compétences" value={stats.total_skills} accent="bg-cyan-100 text-cyan-600" />
+              <StatCard
+                icon={TrendingUp}
+                label="Score moyen de matching"
+                value={stats.average_match_score != null ? `${Math.round(stats.average_match_score * 100)}%` : "—"}
+                accent="bg-rose-100 text-rose-600"
+              />
+              <StatCard icon={Users} label="Inscriptions (7 j)" value={stats.recent_signups} accent="bg-lime-100 text-lime-600" />
+            </div>
+
+            <div className="mt-8 grid gap-6 lg:grid-cols-2">
+              {/* Répartition par rôle */}
+              <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+                <h2 className="mb-4 text-lg font-semibold text-gray-900">Répartition par rôle</h2>
+                <div className="space-y-3">
+                  {Object.entries(stats.users_by_role).map(([role, count]) => {
+                    const pct = stats.total_users ? Math.round((count / stats.total_users) * 100) : 0;
+                    return (
+                      <div key={role}>
+                        <div className="mb-1 flex justify-between text-sm">
+                          <span className="font-medium text-gray-700">{roleLabels[role] ?? role}</span>
+                          <span className="text-gray-500">{count} ({pct}%)</span>
+                        </div>
+                        <div className="h-2 w-full rounded-full bg-gray-100">
+                          <div className="h-2 rounded-full bg-indigo-500" style={{ width: `${pct}%` }} />
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+
+              {/* Accès rapides */}
+              <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+                <h2 className="mb-4 text-lg font-semibold text-gray-900">Accès rapides</h2>
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <Link href="/admin/users" className="flex items-center gap-3 rounded-lg border border-gray-200 p-4 hover:bg-gray-50">
+                    <Users className="h-5 w-5 text-indigo-600" />
+                    <span className="text-sm font-medium text-gray-800">Gérer les utilisateurs</span>
+                  </Link>
+                  <Link href="/admin/monitoring" className="flex items-center gap-3 rounded-lg border border-gray-200 p-4 hover:bg-gray-50">
+                    <Activity className="h-5 w-5 text-amber-600" />
+                    <span className="text-sm font-medium text-gray-800">Logs & performances</span>
+                  </Link>
+                  <Link href="/admin/pipeline" className="flex items-center gap-3 rounded-lg border border-gray-200 p-4 hover:bg-gray-50">
+                    <SlidersVertical className="h-5 w-5 text-rose-600" />
+                    <span className="text-sm font-medium text-gray-800">Configurer le pipeline IA</span>
+                  </Link>
+                </div>
+              </div>
+            </div>
+          </>
+        ) : null}
+      </Layout>
+    </AdminGuard>
+  );
+}

--- a/frontend/src/app/admin/monitoring/page.tsx
+++ b/frontend/src/app/admin/monitoring/page.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { RefreshCw, CheckCircle2, XCircle, AlertTriangle, Info, Database } from "lucide-react";
+import Layout from "@/components/Layout";
+import AdminGuard from "@/components/AdminGuard";
+import { adminApi, type ActivityLog, type SystemHealth } from "@/services/admin";
+import { getErrorMessage } from "@/utils/errorHandler";
+
+const levelStyle: Record<string, { badge: string; icon: React.ElementType }> = {
+  INFO: { badge: "bg-blue-100 text-blue-700", icon: Info },
+  WARNING: { badge: "bg-amber-100 text-amber-700", icon: AlertTriangle },
+  ERROR: { badge: "bg-red-100 text-red-700", icon: XCircle },
+};
+
+function capabilityStatus(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value && typeof value === "object" && "status" in (value as Record<string, unknown>)) {
+    return String((value as Record<string, unknown>).status);
+  }
+  return JSON.stringify(value);
+}
+
+export default function AdminMonitoringPage() {
+  const [health, setHealth] = useState<SystemHealth | null>(null);
+  const [logs, setLogs] = useState<ActivityLog[]>([]);
+  const [levelFilter, setLevelFilter] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  const load = useCallback(() => {
+    setLoading(true);
+    Promise.all([
+      adminApi.getHealth(),
+      adminApi.getLogs({ level: levelFilter || undefined, limit: 100 }),
+    ])
+      .then(([h, l]) => {
+        setHealth(h.data);
+        setLogs(l.data);
+      })
+      .catch((err) => setError(getErrorMessage(err)))
+      .finally(() => setLoading(false));
+  }, [levelFilter]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  return (
+    <AdminGuard>
+      <Layout>
+        <div className="mb-6 flex items-center justify-between">
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900">Logs & performances</h1>
+            <p className="text-gray-600">Supervision du système et journal d&apos;activité</p>
+          </div>
+          <button onClick={load} className="inline-flex items-center gap-2 rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-semibold text-gray-700 hover:bg-gray-50">
+            <RefreshCw className={`h-4 w-4 ${loading ? "animate-spin" : ""}`} /> Actualiser
+          </button>
+        </div>
+
+        {error && (
+          <div className="mb-4 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">{error}</div>
+        )}
+
+        {/* Santé système */}
+        {health && (
+          <div className="mb-8 grid gap-6 lg:grid-cols-3">
+            <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+              <h2 className="mb-4 text-lg font-semibold text-gray-900">État du système</h2>
+              <div className="space-y-3 text-sm">
+                <div className="flex items-center justify-between">
+                  <span className="text-gray-600">Statut global</span>
+                  <span className={`inline-flex items-center gap-1.5 font-medium ${health.status === "ok" ? "text-emerald-600" : "text-amber-600"}`}>
+                    {health.status === "ok" ? <CheckCircle2 className="h-4 w-4" /> : <AlertTriangle className="h-4 w-4" />}
+                    {health.status}
+                  </span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-gray-600">Base de données</span>
+                  <span className={`inline-flex items-center gap-1.5 font-medium ${health.database_connected ? "text-emerald-600" : "text-red-600"}`}>
+                    <Database className="h-4 w-4" />
+                    {health.database_connected ? "Connectée" : "Indisponible"}
+                  </span>
+                </div>
+              </div>
+            </div>
+
+            <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+              <h2 className="mb-4 text-lg font-semibold text-gray-900">Capacités IA</h2>
+              <div className="space-y-2 text-sm">
+                {Object.entries(health.capabilities).length === 0 && (
+                  <p className="text-gray-400">Aucune information</p>
+                )}
+                {Object.entries(health.capabilities).map(([name, value]) => {
+                  const status = capabilityStatus(value);
+                  const ok = /ok|available|true|ready/i.test(status);
+                  const degraded = /degraded|partial/i.test(status);
+                  return (
+                    <div key={name} className="flex items-center justify-between">
+                      <span className="text-gray-600">{name}</span>
+                      <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${ok ? "bg-emerald-100 text-emerald-700" : degraded ? "bg-amber-100 text-amber-700" : "bg-gray-100 text-gray-600"}`}>
+                        {status}
+                      </span>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+
+            <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+              <h2 className="mb-4 text-lg font-semibold text-gray-900">Volumétrie</h2>
+              <div className="grid grid-cols-2 gap-3 text-sm">
+                {Object.entries(health.counts).map(([k, v]) => (
+                  <div key={k} className="rounded-lg bg-gray-50 px-3 py-2">
+                    <p className="text-xs uppercase tracking-wide text-gray-400">{k}</p>
+                    <p className="text-xl font-bold text-gray-900">{v}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Journal d'activité */}
+        <div className="rounded-xl border border-gray-200 bg-white shadow-sm">
+          <div className="flex items-center justify-between border-b border-gray-100 px-5 py-4">
+            <h2 className="text-lg font-semibold text-gray-900">Journal d&apos;activité</h2>
+            <select
+              value={levelFilter}
+              onChange={(e) => setLevelFilter(e.target.value)}
+              className="rounded-lg border border-gray-300 px-3 py-1.5 text-sm focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200"
+            >
+              <option value="">Tous les niveaux</option>
+              <option value="INFO">INFO</option>
+              <option value="WARNING">WARNING</option>
+              <option value="ERROR">ERROR</option>
+            </select>
+          </div>
+          <div className="max-h-[28rem] overflow-y-auto">
+            <table className="min-w-full divide-y divide-gray-100 text-sm">
+              <thead className="bg-gray-50 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+                <tr>
+                  <th className="px-5 py-2.5">Horodatage</th>
+                  <th className="px-5 py-2.5">Niveau</th>
+                  <th className="px-5 py-2.5">Action</th>
+                  <th className="px-5 py-2.5">Détail</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100">
+                {logs.length === 0 ? (
+                  <tr><td colSpan={4} className="px-5 py-8 text-center text-gray-400">Aucune entrée</td></tr>
+                ) : (
+                  logs.map((log) => {
+                    const style = levelStyle[log.level] ?? levelStyle.INFO;
+                    const Icon = style.icon;
+                    return (
+                      <tr key={log.id} className="hover:bg-gray-50">
+                        <td className="whitespace-nowrap px-5 py-2.5 text-gray-500">{new Date(log.timestamp).toLocaleString("fr-FR")}</td>
+                        <td className="px-5 py-2.5">
+                          <span className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium ${style.badge}`}>
+                            <Icon className="h-3 w-3" /> {log.level}
+                          </span>
+                        </td>
+                        <td className="px-5 py-2.5 font-medium text-gray-800">{log.action}</td>
+                        <td className="px-5 py-2.5 text-gray-600">{log.detail ?? "—"}</td>
+                      </tr>
+                    );
+                  })
+                )}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </Layout>
+    </AdminGuard>
+  );
+}

--- a/frontend/src/app/admin/pipeline/page.tsx
+++ b/frontend/src/app/admin/pipeline/page.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Save, RotateCcw, SlidersVertical, AlertTriangle } from "lucide-react";
+import Layout from "@/components/Layout";
+import AdminGuard from "@/components/AdminGuard";
+import { adminApi, type PipelineConfig } from "@/services/admin";
+import { getErrorMessage } from "@/utils/errorHandler";
+
+type EditableKey =
+  | "skill_weight" | "semantic_weight" | "experience_weight"
+  | "education_weight" | "perfect_match_bonus" | "accept_threshold" | "review_threshold";
+
+const WEIGHT_FIELDS: { key: EditableKey; label: string; help: string }[] = [
+  { key: "skill_weight", label: "Compétences", help: "Poids du recouvrement des compétences" },
+  { key: "semantic_weight", label: "Similarité sémantique", help: "Poids du matching sémantique (embeddings)" },
+  { key: "experience_weight", label: "Expérience", help: "Poids de l'adéquation d'expérience" },
+  { key: "education_weight", label: "Formation", help: "Poids de l'adéquation de formation" },
+  { key: "perfect_match_bonus", label: "Bonus match parfait", help: "Bonus appliqué pour un match parfait" },
+];
+
+const THRESHOLD_FIELDS: { key: EditableKey; label: string; help: string }[] = [
+  { key: "accept_threshold", label: "Seuil d'acceptation", help: "Score ≥ ce seuil → Accepté" },
+  { key: "review_threshold", label: "Seuil de revue", help: "Score ≥ ce seuil → À revoir, sinon Rejeté" },
+];
+
+export default function AdminPipelinePage() {
+  const [config, setConfig] = useState<PipelineConfig | null>(null);
+  const [values, setValues] = useState<Record<EditableKey, number>>({} as Record<EditableKey, number>);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+  const [success, setSuccess] = useState("");
+
+  const apply = (cfg: PipelineConfig) => {
+    setConfig(cfg);
+    setValues({
+      skill_weight: cfg.skill_weight,
+      semantic_weight: cfg.semantic_weight,
+      experience_weight: cfg.experience_weight,
+      education_weight: cfg.education_weight,
+      perfect_match_bonus: cfg.perfect_match_bonus,
+      accept_threshold: cfg.accept_threshold,
+      review_threshold: cfg.review_threshold,
+    });
+  };
+
+  useEffect(() => {
+    adminApi.getPipelineConfig()
+      .then((res) => apply(res.data))
+      .catch((err) => setError(getErrorMessage(err)))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const weightSum = WEIGHT_FIELDS.reduce((acc, f) => acc + (values[f.key] || 0), 0);
+  const thresholdInvalid = (values.accept_threshold || 0) < (values.review_threshold || 0);
+
+  const set = (key: EditableKey, raw: string) => {
+    const v = Math.min(1, Math.max(0, parseFloat(raw) || 0));
+    setValues((prev) => ({ ...prev, [key]: v }));
+    setSuccess("");
+  };
+
+  const save = async () => {
+    setSaving(true);
+    setError("");
+    setSuccess("");
+    try {
+      const res = await adminApi.updatePipelineConfig(values);
+      apply(res.data);
+      setSuccess("Paramètres enregistrés. Ils s'appliquent aux prochains calculs de matching.");
+    } catch (err) {
+      setError(getErrorMessage(err));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const reset = async () => {
+    if (!confirm("Réinitialiser tous les paramètres aux valeurs par défaut ?")) return;
+    setSaving(true);
+    setError("");
+    setSuccess("");
+    try {
+      const res = await adminApi.resetPipelineConfig();
+      apply(res.data);
+      setSuccess("Paramètres réinitialisés aux valeurs par défaut.");
+    } catch (err) {
+      setError(getErrorMessage(err));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const Field = ({ field }: { field: { key: EditableKey; label: string; help: string } }) => (
+    <div className="rounded-lg border border-gray-200 p-4">
+      <div className="mb-2 flex items-center justify-between">
+        <label className="text-sm font-semibold text-gray-800">{field.label}</label>
+        <span className="text-sm font-mono text-indigo-600">{(values[field.key] ?? 0).toFixed(2)}</span>
+      </div>
+      <input
+        type="range"
+        min={0}
+        max={1}
+        step={0.01}
+        value={values[field.key] ?? 0}
+        onChange={(e) => set(field.key, e.target.value)}
+        className="w-full accent-indigo-600"
+      />
+      <div className="mt-1 flex items-center justify-between">
+        <p className="text-xs text-gray-500">{field.help}</p>
+        {config && (
+          <span className="text-xs text-gray-400">défaut: {config.defaults[field.key]?.toFixed(2)}</span>
+        )}
+      </div>
+    </div>
+  );
+
+  return (
+    <AdminGuard>
+      <Layout>
+        <div className="mb-6 flex items-center gap-3">
+          <span className="flex h-11 w-11 items-center justify-center rounded-xl bg-rose-100 text-rose-600">
+            <SlidersVertical className="h-6 w-6" />
+          </span>
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900">Paramètres du pipeline IA</h1>
+            <p className="text-gray-600">Poids du scoring et seuils de décision du matching</p>
+          </div>
+        </div>
+
+        {error && <div className="mb-4 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">{error}</div>}
+        {success && <div className="mb-4 rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700">{success}</div>}
+
+        {loading ? (
+          <div className="h-64 animate-pulse rounded-xl bg-gray-100" />
+        ) : (
+          <div className="space-y-6">
+            <section className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+              <div className="mb-4 flex items-center justify-between">
+                <h2 className="text-lg font-semibold text-gray-900">Poids du scoring</h2>
+                <span className={`rounded-full px-3 py-1 text-xs font-medium ${Math.abs(weightSum - 1) < 0.001 ? "bg-emerald-100 text-emerald-700" : "bg-amber-100 text-amber-700"}`}>
+                  Somme des poids : {weightSum.toFixed(2)}
+                </span>
+              </div>
+              {Math.abs(weightSum - 1) >= 0.001 && (
+                <p className="mb-4 flex items-center gap-2 text-xs text-amber-600">
+                  <AlertTriangle className="h-4 w-4" />
+                  La somme des poids (hors bonus) est idéalement proche de 1,00.
+                </p>
+              )}
+              <div className="grid gap-4 sm:grid-cols-2">
+                {WEIGHT_FIELDS.map((f) => <Field key={f.key} field={f} />)}
+              </div>
+            </section>
+
+            <section className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+              <h2 className="mb-4 text-lg font-semibold text-gray-900">Seuils de décision</h2>
+              {thresholdInvalid && (
+                <p className="mb-4 flex items-center gap-2 text-xs text-red-600">
+                  <AlertTriangle className="h-4 w-4" />
+                  Le seuil d&apos;acceptation doit être supérieur ou égal au seuil de revue.
+                </p>
+              )}
+              <div className="grid gap-4 sm:grid-cols-2">
+                {THRESHOLD_FIELDS.map((f) => <Field key={f.key} field={f} />)}
+              </div>
+            </section>
+
+            <div className="flex justify-end gap-3">
+              <button
+                onClick={reset}
+                disabled={saving}
+                className="inline-flex items-center gap-2 rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-semibold text-gray-700 hover:bg-gray-50 disabled:opacity-60"
+              >
+                <RotateCcw className="h-4 w-4" /> Réinitialiser
+              </button>
+              <button
+                onClick={save}
+                disabled={saving || thresholdInvalid}
+                className="inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-5 py-2 text-sm font-semibold text-white hover:bg-indigo-700 disabled:opacity-60"
+              >
+                <Save className="h-4 w-4" /> {saving ? "Enregistrement…" : "Enregistrer"}
+              </button>
+            </div>
+          </div>
+        )}
+      </Layout>
+    </AdminGuard>
+  );
+}

--- a/frontend/src/app/admin/users/page.tsx
+++ b/frontend/src/app/admin/users/page.tsx
@@ -1,0 +1,274 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { Plus, Pencil, Trash2, Search, X, ShieldCheck } from "lucide-react";
+import Layout from "@/components/Layout";
+import AdminGuard from "@/components/AdminGuard";
+import { adminApi, type AdminUser, type Role } from "@/services/admin";
+import { getErrorMessage } from "@/utils/errorHandler";
+
+const ROLES: Role[] = ["admin", "recruiter", "candidate"];
+const roleBadge: Record<Role, string> = {
+  admin: "bg-rose-100 text-rose-700",
+  recruiter: "bg-indigo-100 text-indigo-700",
+  candidate: "bg-emerald-100 text-emerald-700",
+};
+
+interface FormState {
+  id?: number;
+  email: string;
+  full_name: string;
+  role: Role;
+  password: string;
+}
+
+const emptyForm: FormState = { email: "", full_name: "", role: "recruiter", password: "" };
+
+export default function AdminUsersPage() {
+  const [users, setUsers] = useState<AdminUser[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [search, setSearch] = useState("");
+  const [roleFilter, setRoleFilter] = useState<Role | "">("");
+  const [modalOpen, setModalOpen] = useState(false);
+  const [form, setForm] = useState<FormState>(emptyForm);
+  const [saving, setSaving] = useState(false);
+  const [formError, setFormError] = useState("");
+
+  const load = useCallback(() => {
+    setLoading(true);
+    adminApi
+      .listUsers({ search: search || undefined, role: roleFilter || undefined })
+      .then((res) => setUsers(res.data))
+      .catch((err) => setError(getErrorMessage(err)))
+      .finally(() => setLoading(false));
+  }, [search, roleFilter]);
+
+  useEffect(() => {
+    const t = setTimeout(load, 250); // debounce search
+    return () => clearTimeout(t);
+  }, [load]);
+
+  const openCreate = () => {
+    setForm(emptyForm);
+    setFormError("");
+    setModalOpen(true);
+  };
+
+  const openEdit = (u: AdminUser) => {
+    setForm({ id: u.id, email: u.email, full_name: u.full_name, role: u.role, password: "" });
+    setFormError("");
+    setModalOpen(true);
+  };
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSaving(true);
+    setFormError("");
+    try {
+      if (form.id) {
+        const payload: { full_name?: string; role?: Role; password?: string } = {
+          full_name: form.full_name,
+          role: form.role,
+        };
+        if (form.password) payload.password = form.password;
+        await adminApi.updateUser(form.id, payload);
+      } else {
+        await adminApi.createUser({
+          email: form.email,
+          full_name: form.full_name,
+          role: form.role,
+          password: form.password,
+        });
+      }
+      setModalOpen(false);
+      load();
+    } catch (err) {
+      setFormError(getErrorMessage(err));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const remove = async (u: AdminUser) => {
+    if (!confirm(`Supprimer définitivement ${u.email} ?`)) return;
+    try {
+      await adminApi.deleteUser(u.id);
+      load();
+    } catch (err) {
+      setError(getErrorMessage(err));
+    }
+  };
+
+  return (
+    <AdminGuard>
+      <Layout>
+        <div className="mb-6 flex flex-wrap items-center justify-between gap-4">
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900">Gestion des utilisateurs</h1>
+            <p className="text-gray-600">Créer, modifier et supprimer les comptes</p>
+          </div>
+          <button
+            onClick={openCreate}
+            className="inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-700"
+          >
+            <Plus className="h-4 w-4" /> Nouvel utilisateur
+          </button>
+        </div>
+
+        {/* Filtres */}
+        <div className="mb-4 flex flex-wrap gap-3">
+          <div className="relative flex-1 min-w-[220px]">
+            <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
+            <input
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Rechercher par email ou nom…"
+              className="w-full rounded-lg border border-gray-300 py-2 pl-9 pr-3 text-sm focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200"
+            />
+          </div>
+          <select
+            value={roleFilter}
+            onChange={(e) => setRoleFilter(e.target.value as Role | "")}
+            className="rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200"
+          >
+            <option value="">Tous les rôles</option>
+            {ROLES.map((r) => (
+              <option key={r} value={r}>{r}</option>
+            ))}
+          </select>
+        </div>
+
+        {error && (
+          <div className="mb-4 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">{error}</div>
+        )}
+
+        {/* Table */}
+        <div className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
+          <table className="min-w-full divide-y divide-gray-200 text-sm">
+            <thead className="bg-gray-50 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+              <tr>
+                <th className="px-4 py-3">Nom</th>
+                <th className="px-4 py-3">Email</th>
+                <th className="px-4 py-3">Rôle</th>
+                <th className="px-4 py-3">Créé le</th>
+                <th className="px-4 py-3 text-right">Actions</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              {loading ? (
+                <tr><td colSpan={5} className="px-4 py-8 text-center text-gray-400">Chargement…</td></tr>
+              ) : users.length === 0 ? (
+                <tr><td colSpan={5} className="px-4 py-8 text-center text-gray-400">Aucun utilisateur</td></tr>
+              ) : (
+                users.map((u) => (
+                  <tr key={u.id} className="hover:bg-gray-50">
+                    <td className="px-4 py-3 font-medium text-gray-900">
+                      <span className="flex items-center gap-2">
+                        {u.role === "admin" && <ShieldCheck className="h-4 w-4 text-rose-500" />}
+                        {u.full_name}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-gray-600">{u.email}</td>
+                    <td className="px-4 py-3">
+                      <span className={`rounded-full px-2.5 py-0.5 text-xs font-medium ${roleBadge[u.role]}`}>{u.role}</span>
+                    </td>
+                    <td className="px-4 py-3 text-gray-500">{new Date(u.created_at).toLocaleDateString("fr-FR")}</td>
+                    <td className="px-4 py-3">
+                      <div className="flex justify-end gap-2">
+                        <button onClick={() => openEdit(u)} className="rounded-lg p-1.5 text-gray-500 hover:bg-indigo-50 hover:text-indigo-600" title="Modifier">
+                          <Pencil className="h-4 w-4" />
+                        </button>
+                        <button onClick={() => remove(u)} className="rounded-lg p-1.5 text-gray-500 hover:bg-red-50 hover:text-red-600" title="Supprimer">
+                          <Trash2 className="h-4 w-4" />
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+
+        {/* Modal create/edit */}
+        {modalOpen && (
+          <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+            <div className="w-full max-w-md rounded-2xl bg-white p-6 shadow-xl">
+              <div className="mb-4 flex items-center justify-between">
+                <h2 className="text-lg font-bold text-gray-900">
+                  {form.id ? "Modifier l'utilisateur" : "Nouvel utilisateur"}
+                </h2>
+                <button onClick={() => setModalOpen(false)} className="text-gray-400 hover:text-gray-600">
+                  <X className="h-5 w-5" />
+                </button>
+              </div>
+              <form onSubmit={submit} className="space-y-4">
+                <div>
+                  <label className="mb-1 block text-sm font-medium text-gray-700">Email</label>
+                  <input
+                    type="email"
+                    value={form.email}
+                    disabled={!!form.id}
+                    onChange={(e) => setForm({ ...form, email: e.target.value })}
+                    required
+                    className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm disabled:bg-gray-100 focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200"
+                  />
+                </div>
+                <div>
+                  <label className="mb-1 block text-sm font-medium text-gray-700">Nom complet</label>
+                  <input
+                    value={form.full_name}
+                    onChange={(e) => setForm({ ...form, full_name: e.target.value })}
+                    required
+                    minLength={2}
+                    className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200"
+                  />
+                </div>
+                <div>
+                  <label className="mb-1 block text-sm font-medium text-gray-700">Rôle</label>
+                  <select
+                    value={form.role}
+                    onChange={(e) => setForm({ ...form, role: e.target.value as Role })}
+                    className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200"
+                  >
+                    {ROLES.map((r) => (
+                      <option key={r} value={r}>{r}</option>
+                    ))}
+                  </select>
+                </div>
+                <div>
+                  <label className="mb-1 block text-sm font-medium text-gray-700">
+                    {form.id ? "Nouveau mot de passe (optionnel)" : "Mot de passe"}
+                  </label>
+                  <input
+                    type="password"
+                    value={form.password}
+                    onChange={(e) => setForm({ ...form, password: e.target.value })}
+                    required={!form.id}
+                    minLength={form.password ? 6 : undefined}
+                    placeholder={form.id ? "Laisser vide pour ne pas changer" : ""}
+                    className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200"
+                  />
+                </div>
+
+                {formError && (
+                  <div className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">{formError}</div>
+                )}
+
+                <div className="flex justify-end gap-2 pt-2">
+                  <button type="button" onClick={() => setModalOpen(false)} className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50">
+                    Annuler
+                  </button>
+                  <button type="submit" disabled={saving} className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-700 disabled:opacity-60">
+                    {saving ? "Enregistrement…" : form.id ? "Enregistrer" : "Créer"}
+                  </button>
+                </div>
+              </form>
+            </div>
+          </div>
+        )}
+      </Layout>
+    </AdminGuard>
+  );
+}

--- a/frontend/src/app/auth/login/page.tsx
+++ b/frontend/src/app/auth/login/page.tsx
@@ -36,8 +36,9 @@ export default function LoginPage() {
         router.push('/candidate/dashboard');
       } else if (response.user.role === 'recruiter') {
         router.push('/recruiter/dashboard');
+      } else if (response.user.role === 'admin') {
+        router.push('/admin/dashboard');
       } else {
-        // Admin or unknown role
         router.push('/');
       }
     } catch (err: unknown) {
@@ -172,6 +173,7 @@ export default function LoginPage() {
             <ul className="space-y-1">
               <li><strong>Candidat:</strong> alice@test.com / password123</li>
               <li><strong>Recruteur:</strong> bob@test.com / password123</li>
+              <li><strong>Admin:</strong> admin@test.com / password123</li>
             </ul>
           </div>
         </div>

--- a/frontend/src/components/AdminGuard.tsx
+++ b/frontend/src/components/AdminGuard.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+
+/**
+ * Client-side guard for admin pages. Redirects non-admin / unauthenticated
+ * users away. The backend enforces the real authorization (require_admin);
+ * this only improves UX by avoiding flashing protected content.
+ */
+export default function AdminGuard({ children }: { children: React.ReactNode }) {
+  const router = useRouter();
+  const [allowed, setAllowed] = useState(false);
+
+  useEffect(() => {
+    const token = localStorage.getItem("access_token");
+    const role = localStorage.getItem("user_role");
+    if (!token) {
+      router.replace("/auth/login");
+    } else if (role !== "admin") {
+      // Send non-admins to their own space.
+      router.replace(role === "candidate" ? "/candidate/dashboard" : "/recruiter/dashboard");
+    } else {
+      setAllowed(true);
+    }
+  }, [router]);
+
+  if (!allowed) {
+    return (
+      <div className="flex h-64 items-center justify-center text-gray-500">
+        Vérification des autorisations…
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -6,7 +6,7 @@ import { usePathname, useRouter } from "next/navigation";
 import {
   Menu, X, LogOut, LayoutDashboard, Users, Upload, SlidersHorizontal,
   GitCompareArrows, MessageCircle, Heart, FileDown, BrainCircuit, BarChart3,
-  UserCircle, Wrench, ChevronLeft, Moon, Sun,
+  UserCircle, Wrench, ChevronLeft, Moon, Sun, ShieldCheck, Activity, SlidersVertical,
 } from "lucide-react";
 import { useTheme } from "@/hooks/useTheme";
 
@@ -26,6 +26,13 @@ const candidateNav = [
   { href: "/candidate/dashboard", label: "Tableau de bord", icon: LayoutDashboard },
   { href: "/candidate/upload", label: "Déposer mon CV", icon: Upload },
   { href: "/candidate/profile", label: "Mon profil", icon: UserCircle },
+];
+
+const adminNav = [
+  { href: "/admin/dashboard", label: "Tableau de bord", icon: LayoutDashboard },
+  { href: "/admin/users", label: "Utilisateurs", icon: Users },
+  { href: "/admin/monitoring", label: "Logs & Performances", icon: Activity },
+  { href: "/admin/pipeline", label: "Pipeline IA", icon: SlidersVertical },
 ];
 
 export default function Layout({ children }: { children: React.ReactNode }) {
@@ -57,7 +64,8 @@ export default function Layout({ children }: { children: React.ReactNode }) {
   };
 
   const isCandidate = role === "candidate";
-  const nav = isCandidate ? candidateNav : recruiterNav;
+  const isAdmin = role === "admin";
+  const nav = isAdmin ? adminNav : isCandidate ? candidateNav : recruiterNav;
 
   const SidebarContent = ({ mobile = false }: { mobile?: boolean }) => (
     <>
@@ -78,9 +86,10 @@ export default function Layout({ children }: { children: React.ReactNode }) {
       {(sidebarOpen || mobile) && (
         <div className="px-4 pt-3 pb-1">
           <span className={`inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium ${
-            isCandidate ? "bg-emerald-100 text-emerald-700" : "bg-indigo-100 text-indigo-700"
+            isAdmin ? "bg-rose-100 text-rose-700" : isCandidate ? "bg-emerald-100 text-emerald-700" : "bg-indigo-100 text-indigo-700"
           }`}>
-            {isCandidate ? "Espace Candidat" : "Espace Recruteur"}
+            {isAdmin && <ShieldCheck className="h-3.5 w-3.5" />}
+            {isAdmin ? "Espace Administrateur" : isCandidate ? "Espace Candidat" : "Espace Recruteur"}
           </span>
         </div>
       )}

--- a/frontend/src/services/admin.ts
+++ b/frontend/src/services/admin.ts
@@ -1,0 +1,76 @@
+import apiClient from './api';
+
+export type Role = 'admin' | 'recruiter' | 'candidate';
+
+export interface AdminUser {
+  id: number;
+  email: string;
+  full_name: string;
+  role: Role;
+  created_at: string;
+}
+
+export interface GlobalStats {
+  total_users: number;
+  users_by_role: Record<string, number>;
+  total_candidates: number;
+  total_jobs: number;
+  total_match_results: number;
+  total_feedback: number;
+  total_skills: number;
+  average_match_score: number | null;
+  recent_signups: number;
+}
+
+export interface ActivityLog {
+  id: number;
+  timestamp: string;
+  level: string;
+  action: string;
+  user_id: number | null;
+  detail: string | null;
+}
+
+export interface SystemHealth {
+  status: string;
+  database_connected: boolean;
+  capabilities: Record<string, unknown>;
+  counts: Record<string, number>;
+  log_levels: Record<string, number>;
+}
+
+export interface PipelineConfig {
+  skill_weight: number;
+  semantic_weight: number;
+  experience_weight: number;
+  education_weight: number;
+  perfect_match_bonus: number;
+  accept_threshold: number;
+  review_threshold: number;
+  defaults: Record<string, number>;
+}
+
+export const adminApi = {
+  // Gérer les utilisateurs (CRUD)
+  listUsers: (params?: { role?: Role; search?: string }) =>
+    apiClient.get<AdminUser[]>('/admin/users', { params }),
+  createUser: (data: { email: string; password: string; full_name: string; role: Role }) =>
+    apiClient.post<AdminUser>('/admin/users', data),
+  updateUser: (id: number, data: { full_name?: string; role?: Role; password?: string }) =>
+    apiClient.patch<AdminUser>(`/admin/users/${id}`, data),
+  deleteUser: (id: number) => apiClient.delete(`/admin/users/${id}`),
+
+  // Consulter les statistiques globales
+  getStats: () => apiClient.get<GlobalStats>('/admin/stats'),
+
+  // Superviser les logs et performances
+  getLogs: (params?: { level?: string; action?: string; limit?: number }) =>
+    apiClient.get<ActivityLog[]>('/admin/logs', { params }),
+  getHealth: () => apiClient.get<SystemHealth>('/admin/health'),
+
+  // Configurer les paramètres du pipeline IA
+  getPipelineConfig: () => apiClient.get<PipelineConfig>('/admin/pipeline-config'),
+  updatePipelineConfig: (data: Partial<Omit<PipelineConfig, 'defaults'>>) =>
+    apiClient.put<PipelineConfig>('/admin/pipeline-config', data),
+  resetPipelineConfig: () => apiClient.post<PipelineConfig>('/admin/pipeline-config/reset'),
+};


### PR DESCRIPTION
## Module Administrateur — implémentation des 4 cas d'usage du diagramme PFA

Cette PR implémente la **partie Administrateur** du projet, à partir du diagramme de
cas d'utilisation (`PFA.EAP`, package « Administrateur »). Elle couvre les 4 cas d'usage
admin, côté **backend** et **frontend**, avec contrôle d'accès par rôle et tests.

Un document complet est inclus : [`ADMIN_MODULE.md`](ADMIN_MODULE.md) (détails + procédures de test).

### Cas d'utilisation couverts

| Use case (diagramme) | Endpoint(s) | Page |
|---|---|---|
| S'authentifier | `POST /api/auth/login` (existant) | `/auth/login` |
| Gérer les utilisateurs (CRUD) | `GET/POST/PATCH/DELETE /api/admin/users` | `/admin/users` |
| Consulter les statistiques globales | `GET /api/admin/stats` | `/admin/dashboard` |
| Superviser les logs et performances | `GET /api/admin/logs`, `GET /api/admin/health` | `/admin/monitoring` |
| Configurer les paramètres du pipeline IA | `GET/PUT /api/admin/pipeline-config`, `POST .../reset` | `/admin/pipeline` |

Toutes les routes `/api/admin/*` exigent le rôle `admin` (sinon **403**).

---

## ➕ Fichiers AJOUTÉS

### Backend
- **`backend/app/api/admin.py`** — routeur `/api/admin/*` :
  - Users CRUD : `list_users` (recherche + filtre rôle + pagination), `create_user`,
    `get_user`, `update_user` (nom/rôle/mot de passe), `delete_user`.
  - Garde-fous : interdiction de supprimer son propre compte et de supprimer/rétrograder
    le **dernier administrateur**.
  - `global_stats` (compteurs, répartition par rôle, score moyen, inscriptions 7 j).
  - `list_logs` (filtre niveau/action) et `system_health` (DB, capacités IA, volumétrie).
  - `get/update/reset` de la config du pipeline IA (validation incluse).
- **`backend/app/schemas/admin.py`** — schémas Pydantic : `AdminUserCreate/Update/Response`,
  `GlobalStatsResponse`, `ActivityLogResponse`, `SystemHealthResponse`,
  `PipelineConfigResponse`, `PipelineConfigUpdate`.
- **`backend/app/core/settings_store.py`** — store de configuration du pipeline IA :
  valeurs par défaut (identiques aux constantes historiques), validation
  (bornes [0,1] + `accept_threshold ≥ review_threshold`), persistance en base
  (`SystemSetting`) et cache mémoire pour ne pas impacter le chemin de scoring.

### Frontend
- **`frontend/src/services/admin.ts`** — client API admin (users, stats, logs, health,
  pipeline-config) typé.
- **`frontend/src/components/AdminGuard.tsx`** — garde côté client (redirige les non-admins ;
  l'autorisation réelle reste côté backend).
- **`frontend/src/app/admin/dashboard/page.tsx`** — statistiques globales (cartes,
  répartition par rôle, accès rapides).
- **`frontend/src/app/admin/users/page.tsx`** — tableau CRUD + modale création/édition +
  recherche/filtre.
- **`frontend/src/app/admin/monitoring/page.tsx`** — santé système, capacités IA,
  volumétrie, journal d'activité filtrable.
- **`frontend/src/app/admin/pipeline/page.tsx`** — sliders des poids/seuils, validation
  (somme des poids, cohérence des seuils), enregistrement et réinitialisation.

### Documentation
- **`ADMIN_MODULE.md`** — description de tous les changements + procédures de test
  (manuel UI, `TestClient`, cURL, non-régression scoring, vérifs frontend).

---

## ✏️ Fichiers MODIFIÉS

### Backend
- **`backend/app/models/models.py`** — ajout de deux modèles :
  - `SystemSetting(id, key, value JSON, updated_at, updated_by)` — config runtime.
  - `ActivityLog(id, timestamp, level, action, user_id, detail)` — journal d'audit.
- **`backend/app/core/dependencies.py`** — ajout de :
  - `require_admin` — dépendance FastAPI qui renvoie **403** si l'utilisateur n'est pas admin.
  - `log_activity()` — helper d'audit « best-effort » (ne lève jamais d'exception).
  - import de `UserRole`.
- **`backend/app/services/scoring.py`** — les poids (50/20/15/10) et seuils (0.8/0.5)
  ne sont plus codés en dur : ils sont lus depuis `settings_store`
  (`compute_match_score` et `decide_match`). **Les valeurs par défaut sont identiques**,
  donc le comportement par défaut est inchangé ; un admin peut désormais les ajuster.
- **`backend/app/api/auth.py`** — journalise l'événement `auth.login` à chaque connexion
  (alimente la vue monitoring) ; import de `log_activity`.
- **`backend/app/main.py`** — enregistre le routeur `app.api.admin` et précharge la
  configuration du pipeline au démarrage.
- **`backend/seed_test_users.py`** — ajoute un compte admin de test
  (`admin@test.com` / `password123`).

### Frontend
- **`frontend/src/components/Layout.tsx`** — ajout de la navigation admin (`adminNav`),
  d'un badge « Espace Administrateur », et sélection du menu selon le rôle.
- **`frontend/src/app/auth/login/page.tsx`** — redirige les admins vers `/admin/dashboard`
  et ajoute le compte admin dans l'encart des comptes de test.

---

## ❌ Fichiers SUPPRIMÉS
Aucun fichier supprimé. Aucune route/fonctionnalité existante retirée.

> Note : `backend/ai_talent_finder.db` (churn binaire de seed) et
> `frontend/package-lock.json` (modification préexistante, sans rapport) ont été
> **volontairement exclus** de cette PR pour rester focalisé sur le module admin.

---

## 🗄️ Impacts base de données
Deux nouvelles tables créées automatiquement au démarrage
(`Base.metadata.create_all`) : `system_settings`, `activity_logs`. Aucune table
existante modifiée — pas de migration destructive.

---

## ✅ Tests effectués
- Endpoints admin testés de bout en bout via `TestClient` sur la base Postgres réelle :
  login (200), garde de rôle (**403** pour un recruteur), CRUD users, stats,
  pipeline-config (PUT + validation **422** + reset), health, logs.
- Non-régression du scoring : seuils par défaut préservés
  (`decide_match` 0.85→Accepté, 0.60→À revoir, 0.30→Rejeté).
- Frontend : `tsc --noEmit` et ESLint sans erreur.

Procédures reproductibles détaillées dans `ADMIN_MODULE.md` (§5).

---

## ⚠️ Point d'attention pour les reviewers
`seed_test_users.py` importe `app.core.database` directement : il **ne charge pas**
le `.env` racine et tombe donc sur **SQLite**, alors que l'app (`main.py`) charge le
`.env` racine et utilise **Postgres**. Pour créer l'admin dans la base réellement
utilisée par l'app, voir `ADMIN_MODULE.md` §5.1 (option B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
