### PR TITLE
fix: remplacer URL Railway codee en dur par variable env HF Spaces

### DIFF
--- a/frontend/public/runtime-config.js
+++ b/frontend/public/runtime-config.js
@@ -1,3 +1,4 @@
 // This file is written at build-time as a safe fallback. The docker
 // entrypoint will overwrite it at container start when runtime env is set.
-window.__NEXT_PUBLIC_API_URL = "/api";
+// In production (Vercel), NEXT_PUBLIC_API_URL takes precedence over this file.
+window.__NEXT_PUBLIC_API_URL = "https://RHmaster-ai-talent-finder-backend.hf.space";

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,12 +1,9 @@
 import axios from 'axios';
 
 function resolveApiUrl(): string {
-  // In production, talk directly to the HTTPS backend to avoid frontend proxy redirects.
-  if (process.env.NODE_ENV === 'production') {
-    return 'https://ai-talent-finder-backend-production.up.railway.app/api';
-  }
-
-  // In development, check for explicit API URL override
+  // Always prefer the explicit env variable (works in both dev and production).
+  // NEXT_PUBLIC_API_URL must be set to https://RHmaster-ai-talent-finder-backend.hf.space
+  // in Vercel (no trailing slash, no /api — the /api prefix is appended below).
   const runtimeUrl = typeof window !== 'undefined'
     ? (window as typeof window & { __NEXT_PUBLIC_API_URL?: string }).__NEXT_PUBLIC_API_URL
     : process.env.NEXT_PUBLIC_API_URL;


### PR DESCRIPTION
- Suppression du bloc production hardcode vers railway.app dans resolveApiUrl()
- La fonction lit maintenant toujours NEXT_PUBLIC_API_URL en priorite
- runtime-config.js mis a jour avec URL HF Spaces comme fallback
- Configurer dans Vercel: NEXT_PUBLIC_API_URL=https://RHmaster-ai-talent-finder-backend.hf.space