### PR TITLE
fix: alembic online mode - inject DATABASE_URL, remove silent offline…

### DIFF
--- a/AMELIORATIONS.md
+++ b/AMELIORATIONS.md
@@ -206,3 +206,62 @@ La migration est réversible (`downgrade`).
 5. **Page `/jobs`** : la route existe toujours, seul le lien nav a été retiré. Si des liens externes pointent vers `/jobs`, les rediriger vers `/matching`.
 6. **Tests e2e** : définir `E2E_BASE_URL` dans l'environnement CI pointant vers le déploiement cible.
 7. **Compétences techniques dans le profil candidat** : les `nerData.skills` (compétences tech extraites) ne sont pas encore affichés dans la page `candidates/[id]`. Amélioration facile à ajouter si souhaité.
+
+---
+
+## Batch fix du 2026-06-20 (session 2) — Bug migrations Alembic
+
+### PRIORITÉ 0 — Bug critique : migrations Alembic jamais exécutées sur Supabase
+
+**Symptômes observés :**
+- À chaque démarrage HF : `Generating static SQL`, `Will assume transactional DDL`, puis un bloc `BEGIN; ... COMMIT;` qui rejoue toute la chaîne depuis zéro dans les logs.
+- Les tables existaient déjà, mais la dernière migration (`recruiter_id`) n'était jamais appliquée.
+- Erreur runtime : `psycopg2.errors.UndefinedColumn: column candidates.recruiter_id does not exist`
+- `alembic upgrade head` dans `docker-entrypoint.sh` semblait fonctionner mais ne faisait rien.
+
+**Cause racine (chaîne de 3 défauts) :**
+
+| # | Fichier | Défaut |
+|---|---|---|
+| 1 | `backend/alembic.ini` ligne 66 | `sqlalchemy.url = postgresql://postgres:postgres@localhost:5432/ai_talent_finder` — URL localhost codée en dur |
+| 2 | `backend/alembic/env.py` lignes 76-93 | `run_migrations_online()` : le `except Exception` silencieux appelait `run_migrations_offline()` en cas d'échec de connexion |
+| 3 | `backend/alembic/env.py` lignes 44-66 | `run_migrations_offline()` utilise `as_sql=True` → génère du SQL vers stdout SANS l'exécuter |
+
+**Flux exact :**
+1. `alembic upgrade head` démarre en mode online (pas de `--sql`, pas de `context.is_offline_mode()`)
+2. `engine_from_config()` lit `sqlalchemy.url` depuis `alembic.ini` → URL `localhost:5432`
+3. Connexion impossible (pas de PostgreSQL local dans le container HF) → exception
+4. `except Exception` attrape silencieusement → appelle `run_migrations_offline()`
+5. Mode offline avec `as_sql=True` → Alembic génère le SQL dans stdout (les logs qu'on voyait)
+6. Aucune migration n'est appliquée à Supabase
+7. Au démarrage uvicorn : `Base.metadata.create_all()` dans `main.py:on_startup()` crée les tables manquantes via SQLAlchemy (sans Alembic), ce qui explique pourquoi les tables existaient malgré l'Alembic non fonctionnel. `create_all()` ne modifie pas les tables déjà existantes → `recruiter_id` reste absent.
+
+**Correctif appliqué — `backend/alembic/env.py` :**
+- Ajout en tête de fichier : lecture de `os.environ["DATABASE_URL"]` et injection dans la config Alembic via `config.set_main_option("sqlalchemy.url", _db_url)`, avec normalisation `postgres://` → `postgresql://`.
+- Suppression du bloc `try/except` dans `run_migrations_online()` — toute erreur de connexion doit désormais échouer bruyamment (crash visible dans les logs HF) plutôt que d'être avalée silencieusement.
+- Aucune modification de `alembic.ini` (l'URL localhost reste valable pour le dev local, elle est désormais surchargée en prod par la variable d'env).
+
+**Fichiers modifiés :**
+| Fichier | Changement |
+|---|---|
+| `backend/alembic/env.py` | Injection `DATABASE_URL` avant `engine_from_config`, suppression fallback offline silencieux |
+
+**Commandes SQL manuelles à exécuter sur Supabase AVANT le déploiement** (voir `DEPLOY_STEPS.md` pour le détail complet) :
+
+```sql
+ALTER TABLE candidates ADD COLUMN IF NOT EXISTS recruiter_id INTEGER REFERENCES users(id);
+CREATE INDEX IF NOT EXISTS ix_candidates_recruiter_id ON candidates (recruiter_id);
+UPDATE candidates SET recruiter_id = user_id, user_id = NULL
+WHERE owner_role = 'recruiter' AND user_id IS NOT NULL;
+CREATE TABLE IF NOT EXISTS alembic_version (
+    version_num VARCHAR(32) NOT NULL,
+    CONSTRAINT alembic_version_pkc PRIMARY KEY (version_num)
+);
+DELETE FROM alembic_version;
+INSERT INTO alembic_version (version_num) VALUES ('20260620_add_recruiter_id');
+```
+
+**Statut déploiement HF :**
+- Code GitHub : commit effectué, push effectué.
+- HF Space : le dossier HF Space n'est pas disponible localement. Suivre `DEPLOY_STEPS.md` pour copier `backend/alembic/env.py` vers le clone HF Space et pusher.
+- Validation finale requise après déploiement HF (voir DEPLOY_STEPS.md étape 3).

--- a/DEPLOY_STEPS.md
+++ b/DEPLOY_STEPS.md
@@ -1,0 +1,158 @@
+# DEPLOY_STEPS.md — Déploiement du correctif migrations Alembic
+
+**Date :** 2026-06-20  
+**Bug corrigé :** migrations Alembic en mode offline (SQL généré mais non exécuté sur Supabase)
+
+---
+
+## ORDRE D'EXÉCUTION OBLIGATOIRE
+
+⚠️ Respecter l'ordre ci-dessous. Si le SQL Supabase est exécuté APRÈS le déploiement,
+le container plantera au démarrage (CREATE TABLE sur des tables existantes).
+
+```
+ÉTAPE 1 → SQL sur Supabase   (ajouter recruiter_id + estampiller alembic_version)
+ÉTAPE 2 → Copie vers HF Space + commit + push HF
+ÉTAPE 3 → Vérification des logs HF au démarrage
+```
+
+---
+
+## ÉTAPE 1 — SQL à exécuter sur Supabase (console SQL Supabase ou psql)
+
+### 1a. Diagnostic préalable (lecture seule, aucun risque)
+
+```sql
+-- Vérifier si alembic_version existe et son contenu
+SELECT * FROM alembic_version;
+
+-- Vérifier si recruiter_id existe déjà dans candidates
+SELECT column_name, data_type
+FROM information_schema.columns
+WHERE table_name = 'candidates' AND column_name = 'recruiter_id';
+```
+
+### 1b. Corrections à appliquer
+
+Copier-coller le bloc complet dans la console SQL Supabase :
+
+```sql
+-- Ajouter la colonne recruiter_id si elle n'existe pas encore
+ALTER TABLE candidates
+    ADD COLUMN IF NOT EXISTS recruiter_id INTEGER REFERENCES users(id);
+
+-- Créer l'index si absent
+CREATE INDEX IF NOT EXISTS ix_candidates_recruiter_id ON candidates (recruiter_id);
+
+-- Rétro-remplissage : déplacer user_id → recruiter_id pour les profils recruteur
+-- (les candidats avec owner_role='recruiter' avaient user_id = id du recruteur)
+UPDATE candidates
+SET recruiter_id = user_id, user_id = NULL
+WHERE owner_role = 'recruiter' AND user_id IS NOT NULL;
+
+-- Créer et estampiller alembic_version à la tête de la chaîne
+-- Cela indique à Alembic que TOUTES les migrations sont déjà appliquées
+-- → il ne réessaiera pas de recréer les tables existantes au prochain démarrage
+CREATE TABLE IF NOT EXISTS alembic_version (
+    version_num VARCHAR(32) NOT NULL,
+    CONSTRAINT alembic_version_pkc PRIMARY KEY (version_num)
+);
+DELETE FROM alembic_version;
+INSERT INTO alembic_version (version_num) VALUES ('20260620_add_recruiter_id');
+```
+
+### 1c. Vérification après exécution
+
+```sql
+-- Doit retourner : version_num = '20260620_add_recruiter_id'
+SELECT * FROM alembic_version;
+
+-- Doit retourner la colonne recruiter_id
+SELECT column_name, data_type, is_nullable
+FROM information_schema.columns
+WHERE table_name = 'candidates' AND column_name = 'recruiter_id';
+```
+
+---
+
+## ÉTAPE 2 — Déploiement vers Hugging Face Space
+
+Le repo GitHub et le repo HF Space sont distincts. Le push GitHub ne déclenche pas
+le redéploiement HF. Suivre les étapes ci-dessous.
+
+### 2a. Fichiers modifiés à copier vers le dossier du Space HF
+
+Un seul fichier a été modifié dans ce correctif :
+
+| Chemin dans le repo GitHub | Chemin dans le dossier HF Space |
+|---|---|
+| `backend/alembic/env.py` | `alembic/env.py` |
+
+```bash
+# Depuis la racine du repo GitHub, vers le clone du HF Space
+# Adapter le chemin vers votre dossier HF Space local
+cp backend/alembic/env.py /chemin/vers/ai-talent-finder-backend/alembic/env.py
+```
+
+### 2b. Commit et push vers HF Space
+
+```bash
+cd /chemin/vers/ai-talent-finder-backend
+
+git add alembic/env.py
+git commit -m "fix: alembic online mode - inject DATABASE_URL from env, remove offline fallback"
+git push
+```
+
+### 2c. Surveiller les logs de démarrage HF
+
+Dans les logs HF Space, au démarrage suivant vous devez voir :
+
+```
+==> Migrations Alembic
+INFO  [alembic.runtime.migration] Context impl PostgreSQLImpl.
+INFO  [alembic.runtime.migration] Will assume transactional DDL.
+INFO  [alembic.runtime.migration] Running upgrade  -> ...
+==> Uvicorn sur le port 7860
+```
+
+**Ce que vous NE devez PLUS voir :**
+- `Generating static SQL`
+- `BEGIN;\n...\nCOMMIT;` (le gros bloc SQL vers stdout)
+
+Si `alembic_version` était correctement estampillé à l'étape 1, vous verrez :
+```
+INFO  [alembic.runtime.migration] Running upgrade 20260617_... -> 20260620_add_recruiter_id
+```
+Ou simplement rien si déjà à la tête (déjà estampillé).
+
+---
+
+## ÉTAPE 3 — Validation fonctionnelle
+
+Le bug est résolu quand :
+
+1. Uploader 3 CV différents en tant que recruteur crée **3 lignes distinctes** dans `candidates`
+2. Aucune erreur 500 sur `POST /candidates/upload` ni `GET /candidates/`
+3. Requête SQL de vérification sur Supabase :
+
+```sql
+-- Doit montrer 3 lignes avec des recruiter_id remplis
+SELECT id, full_name, recruiter_id, owner_role, created_at
+FROM candidates
+WHERE owner_role = 'recruiter'
+ORDER BY created_at DESC
+LIMIT 10;
+```
+
+---
+
+## Résumé des causes racines du bug
+
+| Symptôme | Cause |
+|---|---|
+| SQL affiché dans les logs mais non exécuté | `env.py` tombait en mode offline (`as_sql=True`) |
+| Chute en mode offline à chaque démarrage | `run_migrations_online()` échouait sur `localhost:5432` (URL codée en dur dans `alembic.ini`) |
+| Exception silencieuse | `except Exception: run_migrations_offline()` avalait l'erreur |
+| Tables présentes malgré Alembic non fonctionnel | `Base.metadata.create_all()` dans `app/main.py:on_startup()` créait les tables via SQLAlchemy |
+| `recruiter_id` absent | `create_all()` ne modifie pas les tables existantes, contrairement à Alembic |

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -1,3 +1,4 @@
+import os
 from logging.config import fileConfig
 
 from sqlalchemy import engine_from_config
@@ -5,19 +6,10 @@ from sqlalchemy import pool
 
 from alembic import context
 
-# this is the Alembic Config object, which provides
-# access to the values within the .ini file in use.
 config = context.config
 
-# Interpret the config file for Python logging.
-# This line sets up loggers basically.
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
-
-# add your model's MetaData object here
-# for 'autogenerate' support
-# from myapp import mymodel
-# target_metadata = mymodel.Base.metadata
 
 from app.core.database import Base
 from app.models.models import (
@@ -35,24 +27,19 @@ from app.models.models import (
 
 target_metadata = Base.metadata
 
-# other values from the config, defined by the needs of env.py,
-# can be acquired:
-# my_important_option = config.get_main_option("my_important_option")
-# ... etc.
+# Inject the real DATABASE_URL from environment, overriding the placeholder in alembic.ini.
+# Without this, Alembic falls back to the hardcoded localhost URL in alembic.ini,
+# fails to connect, and silently switches to offline mode (prints SQL instead of running it).
+_db_url = os.environ.get("DATABASE_URL", "").strip()
+if _db_url:
+    if _db_url.startswith("postgres://"):
+        _db_url = _db_url.replace("postgres://", "postgresql://", 1)
+    config.set_main_option("sqlalchemy.url", _db_url)
 
 
 def run_migrations_offline() -> None:
-    """Run migrations in 'offline' mode.
-
-    This configures the context with just a URL
-    and not an Engine, though an Engine is acceptable
-    here as well.  By skipping the Engine creation
-    we don't even need a DBAPI to be available.
-
-    Calls to context.execute() here emit the given string to the
-    script output.
-
-    """
+    """Run migrations in 'offline' mode (generates SQL to stdout, does NOT apply it).
+    Only used when invoked explicitly with --sql flag or context.is_offline_mode()."""
     url = config.get_main_option("sqlalchemy.url")
     context.configure(
         url=url,
@@ -67,30 +54,20 @@ def run_migrations_offline() -> None:
 
 
 def run_migrations_online() -> None:
-    """Run migrations in 'online' mode.
+    """Run migrations in 'online' mode (applies migrations directly to the database)."""
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
 
-    In this scenario we need to create an Engine
-    and associate a connection with the context.
-
-    """
-    try:
-        connectable = engine_from_config(
-            config.get_section(config.config_ini_section, {}),
-            prefix="sqlalchemy.",
-            poolclass=pool.NullPool,
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection, target_metadata=target_metadata
         )
 
-        with connectable.connect() as connection:
-            context.configure(
-                connection=connection, target_metadata=target_metadata
-            )
-
-            with context.begin_transaction():
-                context.run_migrations()
-    except Exception:
-        # If connection fails (e.g., database doesn't exist yet),
-        # use offline mode for autogenerate
-        run_migrations_offline()
+        with context.begin_transaction():
+            context.run_migrations()
 
 
 if context.is_offline_mode():

--- a/chemise.md
+++ b/chemise.md
@@ -1,0 +1,221 @@
+# chemise.md — Documentation des changements et état du programme
+
+**Projet :** AI-Talent-Finder  
+**Date de rédaction :** 2026-06-20  
+**Auteur :** Claude (session correctif migrations Alembic)
+
+---
+
+## 1. Ce qui a changé dans cette session
+
+### Fichier modifié : `backend/alembic/env.py`
+
+**Problème résolu :** Les migrations Alembic n'étaient jamais appliquées réellement à la base Supabase depuis au moins plusieurs semaines. Le SQL était généré et affiché dans les logs mais jamais exécuté.
+
+**Ce qui était cassé (avant) :**
+
+```python
+# run_migrations_online() dans l'ancien env.py
+try:
+    connectable = engine_from_config(...)  # lit localhost:5432 depuis alembic.ini
+    ...
+except Exception:
+    run_migrations_offline()  # ← avale l'erreur et génère du SQL vers stdout
+```
+
+La fonction `run_migrations_offline()` contient `as_sql=True`, ce qui fait que le SQL
+est écrit dans stdout au lieu d'être exécuté sur la base.
+
+**Ce qui est corrigé (après) :**
+
+```python
+# Début du nouveau env.py
+_db_url = os.environ.get("DATABASE_URL", "").strip()
+if _db_url:
+    if _db_url.startswith("postgres://"):
+        _db_url = _db_url.replace("postgres://", "postgresql://", 1)
+    config.set_main_option("sqlalchemy.url", _db_url)
+```
+
+`DATABASE_URL` (variable d'env Supabase) est injectée dans la config Alembic AVANT
+que `engine_from_config()` ne lise `sqlalchemy.url`. Plus de connexion à localhost,
+plus de fallback silencieux vers le mode offline.
+
+**Fichiers créés dans cette session :**
+
+| Fichier | But |
+|---|---|
+| `DEPLOY_STEPS.md` | Guide étape-par-étape pour déployer le correctif (SQL Supabase + push HF) |
+| `chemise.md` | Ce document |
+
+---
+
+## 2. Architecture globale du programme
+
+### Backend (FastAPI + SQLAlchemy + Alembic)
+
+**Déploiement :** Hugging Face Spaces (Docker). Repo HF Space séparé du repo GitHub.  
+**Base de données :** PostgreSQL sur Supabase, accédée via `DATABASE_URL` (variable d'env).
+
+```
+backend/
+├── app/
+│   ├── main.py               ← Application FastAPI, startup hook (create_all)
+│   ├── core/
+│   │   ├── database.py       ← engine, SessionLocal, Base (lit DATABASE_URL)
+│   │   └── ...
+│   ├── api/
+│   │   ├── candidates.py     ← Upload CV, liste candidats, logique recruiter_id
+│   │   ├── auth.py           ← Login/register
+│   │   ├── matching.py       ← Matching IA
+│   │   └── ...
+│   └── models/
+│       └── models.py         ← Modèles SQLAlchemy (Candidate, User, etc.)
+├── alembic/
+│   ├── env.py                ← ← MODIFIÉ — injecte DATABASE_URL
+│   └── versions/             ← Chaîne de migrations
+│       ├── 53a6f0317e90_initial_models.py          (root)
+│       ├── 4402afc8b225_add_candidates_table.py
+│       ├── 000001_create_all_tables.py
+│       ├── add_ner_extraction_columns.py
+│       ├── 20260513_create_recruiter_feedback.py
+│       ├── 20260615_add_admin_fields.py
+│       ├── 20260617_add_profile_visibility.py
+│       └── 20260620_add_recruiter_id.py             (head)
+├── alembic.ini               ← URL localhost (dev local) — surchargée en prod par env.py
+├── Dockerfile
+└── docker-entrypoint.sh      ← alembic upgrade head → uvicorn
+```
+
+**Chaîne de migrations (ordre) :**
+```
+53a6f0317e90 → 4402afc8b225 → 000001_create_all_tables → add_ner_extraction
+→ 20260513_create_recruiter_feedback → 20260615_add_admin_fields
+→ 20260617_add_profile_visibility → 20260620_add_recruiter_id  (HEAD)
+```
+
+### Frontend (Next.js)
+
+**Déploiement :** Vercel  
+**URL backend :** `NEXT_PUBLIC_API_URL` (variable d'env Vercel)
+
+```
+frontend/
+├── src/
+│   ├── app/
+│   │   ├── recruiter/        ← Pages recruteur (dashboard, upload, matching...)
+│   │   └── ...
+│   ├── services/
+│   │   ├── candidates.ts     ← Appels API candidats
+│   │   └── ...
+│   └── components/
+│       └── Layout.tsx        ← Navigation principale
+```
+
+---
+
+## 3. Problèmes résolus dans les deux dernières sessions
+
+| # | Problème | Statut |
+|---|---|---|
+| P0 | Migrations Alembic en mode offline : colonnes comme `recruiter_id` jamais ajoutées | **Corrigé** (cette session) |
+| P1 | Candidats écrasés : chaque upload recruteur écrasait le précédent | **Corrigé** (session précédente) |
+| P2 | NER : noms trop courts (1 mot) ou trop longs (4+ tokens) rejetés | **Corrigé** |
+| P3 | Frontend masquait des candidats valides (double filtrage `cv_path`) | **Corrigé** |
+| P4 | Dashboard recruteur : statistiques codées en dur à 0 | **Corrigé** |
+| P5 | Navigation : entrées redondantes Critères/Matching | **Corrigé** |
+| P6 | Références Railway obsolètes dans configs, tests, README | **Corrigé** |
+
+---
+
+## 4. Problèmes restants connus
+
+### 4.1 Colonne `recruiter_id` absente physiquement dans Supabase
+
+**Statut :** En attente d'exécution manuelle SQL + déploiement HF  
+**Impact :** `POST /candidates/upload` et `GET /candidates/` retournent 500  
+**Action requise :** Suivre `DEPLOY_STEPS.md` intégralement (SQL d'abord, push HF ensuite)
+
+### 4.2 `Base.metadata.create_all()` redondant dans `main.py`
+
+**Fichier :** `backend/app/main.py` ligne 82  
+**Statut :** Non critique après la correction d'Alembic  
+**Explication :** Après le correctif, Alembic crée les tables au démarrage via `upgrade head`.
+`create_all()` tourne ensuite et ne fait rien (les tables existent déjà). Si Alembic échoue
+(DATABASE_URL manquante, Supabase inaccessible), `create_all()` prend le relais mais
+n'appliquera pas les colonnes nouvelles des migrations futures.  
+**Recommandation :** À long terme, supprimer `create_all()` du startup et laisser Alembic
+être la seule source de vérité pour le schéma. Pas urgent tant que le correctif est déployé.
+
+### 4.3 Compétences techniques non affichées dans le profil candidat
+
+**Fichier :** `frontend/src/app/recruiter/candidates/[id]/page.tsx` (ou équivalent)  
+**Statut :** Fonctionnalité partielle — les soft skills NER sont affichés mais pas les
+compétences tech extraites (`nerData.skills`)  
+**Action requise :** Ajouter l'affichage de `nerData.skills` dans la section Compétences
+du profil, sur le même pattern que `nerData.soft_skills`
+
+### 4.4 Page `/jobs` toujours accessible mais sans lien nav
+
+**Fichier :** `frontend/src/app/recruiter/jobs/...`  
+**Statut :** La page existe, le lien de navigation a été retiré (fusionné dans `/matching`)  
+**Impact :** Aucun si personne n'utilise l'URL directement. Pas de redirection en place.  
+**Recommandation :** Ajouter un `redirect()` de `/jobs` vers `/matching` si des bookmarks existent.
+
+### 4.5 Apostrophes typographiques potentielles dans des fichiers anciens
+
+**Contexte :** Une précédente livraison de `resume_ner_extractor.py` avait des apostrophes
+courbes (`'`) au lieu d'apostrophes ASCII (`'`) → SyntaxError au runtime.  
+**Statut :** Corrigé pour ce fichier. Les autres fichiers n'ont pas été audités exhaustivement.  
+**Commande de vérification rapide :**
+```bash
+grep -rn $'\xe2\x80\x98\|\xe2\x80\x99' backend/app/ backend/ai_module/
+```
+(retourne les lignes avec `'` ou `'` — doit être vide)
+
+### 4.6 Chaîne de migrations non linéaire potentielle
+
+**Statut :** Vérifié — la chaîne est bien linéaire (pas de branches).  
+**Risque résiduel :** Si une future migration est créée avec `alembic revision` sans
+préciser `--head`, elle pourrait créer une branche. Toujours utiliser `alembic revision --head head --autogenerate`.
+
+---
+
+## 5. Variables d'environnement requises sur HF Space
+
+| Variable | Obligatoire | Description |
+|---|---|---|
+| `DATABASE_URL` | **Oui** | URL Supabase PostgreSQL (format `postgresql://...`) |
+| `SECRET_KEY` | **Oui** | Clé JWT pour l'authentification |
+| `HF_TOKEN_CHATBOT` | Non | Token HF pour le chatbot QWEN |
+| `CHATBOT_MODEL` | Non | Modèle chatbot (défaut dans le code) |
+| `ANTHROPIC_API_KEY` | Non | Pour les features Anthropic |
+| `DEPLOY_ENV` | Recommandé | `production` pour activer le middleware HTTPS |
+
+Si `DATABASE_URL` est absente, `database.py` bascule sur SQLite local et Alembic
+n'injectera rien (condition `if _db_url:`) → les migrations ne tourneront pas mais
+ne planteront pas non plus. Le log devra montrer l'avertissement SQLite.
+
+---
+
+## 6. Commandes utiles (développement local)
+
+```bash
+# Lancer le backend localement (avec .env à la racine du projet)
+cd backend
+uvicorn app.main:app --reload --port 8000
+
+# Appliquer les migrations Alembic en local
+cd backend
+DATABASE_URL=postgresql://... alembic upgrade head
+
+# Générer une nouvelle migration
+cd backend
+DATABASE_URL=postgresql://... alembic revision --head head --autogenerate -m "description"
+
+# Vérifier la syntaxe Python des fichiers
+python3 -m py_compile alembic/env.py
+
+# Chercher les apostrophes typographiques
+grep -rn $'\xe2\x80\x98\|\xe2\x80\x99' app/ ai_module/
+```


### PR DESCRIPTION
… fallback

- env.py: lit DATABASE_URL depuis l'env et l'injecte via set_main_option avant engine_from_config
- env.py: supprime le try/except qui basculait silencieusement en mode offline (as_sql=True)
- DEPLOY_STEPS.md: guide SQL Supabase + copie HF Space + validation
- AMELIORATIONS.md: diagnostic cause racine ajoute
- chemise.md: documentation architecture, changements, problemes restants