### PR TITLE
fix: NER extraction quality - reduce noise, fix name sort, BOM robust…

### DIFF
--- a/backend/ai_module/nlp/resume_ner_extractor.py
+++ b/backend/ai_module/nlp/resume_ner_extractor.py
@@ -161,7 +161,7 @@ class ResumeNERExtractor:
     STOP_HEADERS = {
         "skills", "competences", "compétences", "technical skills", "langues",
         "languages", "profil", "profile", "contact", "summary", "resume", "résumé",
-        "centres d'interet", "centres d’intérêt", "interets", "intérêts",
+        "centres d'interet", "centres d'intérêt", "interets", "intérêts",
         "projects", "projets", "certifications", "hobbies",
     }
 
@@ -303,6 +303,9 @@ class ResumeNERExtractor:
             line = raw_line.strip().strip('•*-').strip()
             normalized = self._normalize_for_matching(line)
 
+            # Reject very short lines — single chars are OCR artifacts, not names
+            if len(line) < 3:
+                continue
             if not line or '@' in line or 'http' in normalized or self._is_section_header(normalized):
                 continue
             if any(token in normalized for token in ('linkedin', 'github', 'contact', 'profil', 'profile')):
@@ -311,11 +314,12 @@ class ResumeNERExtractor:
                 continue
 
             words = [word for word in re.split(r'\s+', line) if word]
-            # Allow 1-4 words: single-name aliases, compound names, and particle names (de, van...)
-            if not 1 <= len(words) <= 4:
+            # Require 2-4 words: real names have at least first + last name
+            # (single-word aliases create too much noise from headers/bullets)
+            if not 2 <= len(words) <= 4:
                 continue
 
-            alpha_words = sum(1 for word in words if re.search(r'[A-Za-zÀ-ÿ]', word))
+            alpha_words = sum(1 for word in words if re.search(r'[A-Za-z\xc0-\xff]', word))
             if alpha_words != len(words):
                 continue
 
@@ -327,25 +331,29 @@ class ResumeNERExtractor:
                 score += 3
 
             # ALL_CAPS name (common in French CVs): highest match
-            if re.fullmatch(r"[A-ZÀ-Ÿ][A-ZÀ-Ÿ'\-]+(?:\s+[A-ZÀ-Ÿ][A-ZÀ-Ÿ'\-]+){0,3}", line):
+            if re.fullmatch(r"[A-Z\xc0-\xde][A-Z\xc0-\xde'\-]+(?:\s+[A-Z\xc0-\xde][A-Z\xc0-\xde'\-]+){1,3}", line):
                 score += 5
             # Title-case properly capitalized name
-            elif re.fullmatch(r"[A-ZÀ-Ÿ][A-Za-zÀ-ÿ'\-]+(?:\s+[A-ZÀ-Ÿ][A-Za-zÀ-ÿ'\-]+){0,3}", line):
+            elif re.fullmatch(r"[A-Z\xc0-\xde][A-Za-z\xc0-\xff'\-]+(?:\s+[A-Z\xc0-\xde][A-Za-z\xc0-\xff'\-]+){1,3}", line):
                 score += 4
-            # Mixed-case but all letters
-            elif all(re.search(r'[A-Za-zÀ-ÿ]', w) for w in words):
-                score += 2
+            # Mixed-case but all letters — lower confidence
+            elif all(re.search(r'[A-Za-z\xc0-\xff]', w) for w in words):
+                score += 1
 
             if any(keyword in normalized for keyword in ('experience', 'formation', 'education', 'profil', 'contact')):
                 score -= 4
 
+            # Only keep if score is positive after penalties
+            if score <= 0:
+                continue
+
             candidates.append((score, line.title()))
 
             # Also evaluate segmented fragments when a line contains separators like pipes or dashes.
-            for fragment in re.split(r"\s*[|/·•]\s*|\s+-\s+|\s+–\s+|\s+—\s+", line):
+            for fragment in re.split(r"\s*[|/\xb7•]\s*|\s+-\s+|\s+–\s+|\s+—\s+", line):
                 fragment = fragment.strip()
                 fragment_normalized = self._normalize_for_matching(fragment)
-                if not fragment or fragment == line:
+                if not fragment or fragment == line or len(fragment) < 3:
                     continue
                 if '@' in fragment or 'http' in fragment_normalized or self._is_section_header(fragment_normalized):
                     continue
@@ -356,14 +364,14 @@ class ResumeNERExtractor:
                 fragment_words = [word for word in re.split(r'\s+', fragment) if word]
                 if not 2 <= len(fragment_words) <= 4:
                     continue
-                if not all(re.search(r'[A-Za-zÀ-ÿ]', word) for word in fragment_words):
+                if not all(re.search(r'[A-Za-z\xc0-\xff]', word) for word in fragment_words):
                     continue
                 fragment_score = 2
                 if index < 10:
                     fragment_score += 2
-                if re.fullmatch(r"[A-ZÀ-Ÿ][A-ZÀ-Ÿ'’\-]+(?:\s+[A-ZÀ-Ÿ][A-ZÀ-Ÿ'’\-]+){1,3}", fragment):
+                if re.fullmatch(r"[A-Z\xc0-\xde][A-Z\xc0-\xde'\-]+(?:\s+[A-Z\xc0-\xde][A-Z\xc0-\xde'\-]+){1,3}", fragment):
                     fragment_score += 4
-                elif re.fullmatch(r"[A-ZÀ-Ÿ][A-Za-zÀ-ÿ'’\-]+(?:\s+[A-ZÀ-Ÿ][A-Za-zÀ-ÿ'’\-]+){1,3}", fragment):
+                elif re.fullmatch(r"[A-Z\xc0-\xde][A-Za-z\xc0-\xff'\-]+(?:\s+[A-Z\xc0-\xde][A-Za-z\xc0-\xff'\-]+){1,3}", fragment):
                     fragment_score += 3
                 candidates.append((fragment_score, fragment.title()))
 
@@ -372,11 +380,14 @@ class ResumeNERExtractor:
                 return [email_fallback]
             return []
 
-        candidates.sort(key=lambda item: (-item[0], len(item[1])))
+        # Sort by score descending; on tie, prefer LONGER names (more complete)
+        # Using -len so that longer strings sort first (ascending sort picks smallest first)
+        candidates.sort(key=lambda item: (-item[0], -len(item[1])))
         best_name = candidates[0][1]
 
-        if len(best_name) < 3 and email_fallback:
-            return [email_fallback]
+        # Always reject very short "names" regardless of email fallback
+        if len(best_name) < 4:
+            return [email_fallback] if email_fallback else []
 
         return [best_name]
 
@@ -428,7 +439,19 @@ class ResumeNERExtractor:
                 continue
             if '@' in cleaned or 'linkedin.com' in cleaned.lower() or re.search(r'\d{2}\s?\d{2}', cleaned):
                 continue
-            for match in re.findall(r'\b([A-ZÀ-Ÿ][A-Za-zÀ-ÿ\-]+\s*,\s*[A-ZÀ-Ÿ][A-Za-zÀ-ÿ\-]+)\b', cleaned):
+            # Require both parts to be at least 3 chars and title-cased (e.g. "Paris, France")
+            # Avoids matching skill pairs like "Python, Django" or "Junior, CDI"
+            for match in re.findall(
+                r'\b([A-Z\xc0-\xde][A-Za-z\xc0-\xff\-]{2,}\s*,\s*[A-Z\xc0-\xde][A-Za-z\xc0-\xff\-]{2,})\b',
+                cleaned
+            ):
+                parts = [p.strip() for p in match.split(',')]
+                # Reject if any part is a known skill, job keyword or education keyword
+                normalized_parts = [self._normalize_for_matching(p) for p in parts]
+                if any(p in self.LANGUAGE_NAMES for p in normalized_parts):
+                    continue
+                if any(any(kw in p for kw in self.EDUCATION_KEYWORDS) for p in normalized_parts):
+                    continue
                 locations.append(match.strip())
         return list(dict.fromkeys(locations))[:3]
     
@@ -474,16 +497,18 @@ class ResumeNERExtractor:
                 if next_clean and self._looks_like_company_line(next_clean) and self._looks_like_job_title(line):
                     job_titles.add(line)
 
-        # Fallback: detect title/company pairs globally when OCR breaks section boundaries.
-        for index, raw_line in enumerate(lines):
-            line = raw_line.strip().strip('•*-').strip()
-            if not line:
-                continue
-            if self._looks_like_job_title(line) and index + 1 < len(lines):
-                next_clean = lines[index + 1].strip().strip('•*-').strip()
-                if next_clean and self._looks_like_company_line(next_clean):
-                    job_titles.add(line)
-        
+        # Fallback: detect title/company pairs globally only when section-based
+        # extraction found nothing (avoids noisy duplicates from global scan).
+        if not job_titles:
+            for index, raw_line in enumerate(lines):
+                line = raw_line.strip().strip('•*-').strip()
+                if not line:
+                    continue
+                if self._looks_like_job_title(line) and index + 1 < len(lines):
+                    next_clean = lines[index + 1].strip().strip('•*-').strip()
+                    if next_clean and self._looks_like_company_line(next_clean):
+                        job_titles.add(line)
+
         return list(job_titles)[:5]
     
     def _extract_companies(self, text: str) -> List[str]:
@@ -521,13 +546,15 @@ class ResumeNERExtractor:
                 if company:
                     companies.add(company)
 
-        # Fallback: extract company lines globally when section headers are merged.
-        for raw_line in text.split('\n'):
-            line = raw_line.strip()
-            if self._looks_like_company_line(line):
-                company = self._extract_company_from_line(line)
-                if company:
-                    companies.add(company)
+        # Fallback: extract company lines globally only when section-based extraction
+        # found nothing (avoids noise from address lines, education dates, etc.).
+        if not companies:
+            for raw_line in text.split('\n'):
+                line = raw_line.strip()
+                if self._looks_like_company_line(line):
+                    company = self._extract_company_from_line(line)
+                    if company:
+                        companies.add(company)
 
         for company in known_companies:
             if company in text_lower and company not in {'linkedin', 'github'}:
@@ -580,7 +607,9 @@ class ResumeNERExtractor:
         """Extract technical skills"""
         skills = set()
 
-        tokens = set(re.findall(r"[a-zA-Z0-9\+\#\-\.]+", text_lower))
+        # Include accented chars (xc0-xff) so French skills like "developpeur",
+        # "medecin", "comptabilite" are captured from token set matching.
+        tokens = set(re.findall(r"[a-z\xc0-\xff0-9\+\#\-\.]+", text_lower))
 
         for skill in self.TECH_SKILLS:
             if " " in skill:
@@ -1059,7 +1088,7 @@ class ResumeNERExtractor:
     def _extract_company_from_line(self, line: str) -> str:
         candidate = line.split('|', 1)[0].strip()
         candidate = re.split(r"\s*\(\s*\d{4}.*$", candidate)[0].strip()
-        candidate = re.split(r"\s*[-–]\s*[A-ZÀ-Ÿ][A-Za-zÀ-ÿ\s&'’.-]{1,40}$", candidate)[0].strip()
+        candidate = re.split(r"\s*[-–]\s*[A-ZÀ-Ÿ][A-Za-zÀ-ÿ\s&''.-]{1,40}$", candidate)[0].strip()
         candidate = candidate.split(',', 1)[0].strip()
         candidate = candidate.strip('•*-').strip()
 
@@ -1086,21 +1115,22 @@ class ResumeNERExtractor:
             return False
         if line.endswith('.') or line.endswith(':'):
             return False
-        if any(token in normalized for token in ('bénévolat', 'randonnée', 'voyage', 'théâtre', 'concerts', 'loisirs', 'interets', 'intérêts')):
+        if any(token in normalized for token in ('benevolat', 'randonnee', 'voyage', 'theatre', 'concerts', 'loisirs', 'interets')):
             return False
 
         words = [word for word in re.split(r'\s+', line.strip()) if word]
         if not 1 <= len(words) <= 6:
             return False
 
+        # Must contain at least one known job keyword — the old catch-all
+        # `all words contain a letter` was far too permissive and produced
+        # massive noise (education lines, location lines, hobby lines, etc.)
         if any(keyword in normalized for keyword in self.JOB_KEYWORDS):
             return True
 
+        # Single long all-alpha word (e.g. "Informaticien", "Comptable")
         if len(words) == 1:
             return len(words[0]) >= 7 and words[0].isalpha()
-
-        if all(re.search(r'[A-Za-zÀ-ÿ]', word) for word in words):
-            return True
 
         return False
 

--- a/backend/app/services/cv_extractor.py
+++ b/backend/app/services/cv_extractor.py
@@ -354,18 +354,30 @@ class CVExtractionService:
 
         return cleaned
 
+    # BOM and zero-width Unicode chars to strip from extracted text / names.
+    # Using explicit codepoints is more robust than embedding literal Unicode chars.
+    _ZERO_WIDTH_CHARS = (
+        "﻿"  # BOM / Zero-width no-break space
+        "￾"  # Reversed BOM
+        "​"  # Zero-width space
+        "‌"  # Zero-width non-joiner
+        "‍"  # Zero-width joiner
+        "⁠"  # Word joiner
+        "­"  # Soft hyphen
+    )
+
     def _clean_name(self, name: Any) -> Optional[str]:
         value = str(name or "").strip()
-        # Strip UTF-8 BOM and zero-width chars that cause capitalize() to lowercase
-        # the real first letter (BOM becomes the first char, everything else lowercased).
-        value = value.lstrip("﻿￾​‌‍⁠").strip()
-        if not value:
+        # Strip BOM and zero-width chars — if not removed, capitalize() treats the
+        # invisible char as the first character and lowercases the real first letter.
+        value = value.strip(self._ZERO_WIDTH_CHARS).strip()
+        if not value or len(value) < 4:
             return None
         if "@" in value or "http" in value.lower():
             return None
         if any(ch.isdigit() for ch in value):
             return None
-        words = [w.lstrip("﻿￾​‌‍⁠") for w in re.split(r"\s+", value) if w]
+        words = [w.strip(self._ZERO_WIDTH_CHARS) for w in re.split(r"\s+", value) if w]
         words = [w for w in words if w]
         if len(words) < 2 or len(words) > 4:
             return None
@@ -464,9 +476,9 @@ class CVExtractionService:
 
     def _normalize_text_for_extraction(self, text: str) -> str:
         """Normalize noisy PDF extraction output to improve entity detection."""
-        # Remove UTF-8 BOM (﻿) and similar zero-width chars that corrupt the first
-        # word of extracted text and cause name capitalize() bugs.
-        normalized = text.lstrip("﻿￾​‌‍")
+        # Strip BOM and zero-width chars from the start (and end) of the text.
+        # Using the same _ZERO_WIDTH_CHARS constant for consistency.
+        normalized = text.strip(self._ZERO_WIDTH_CHARS)
         normalized = normalized.replace("\r", "\n")
         normalized = re.sub(r"[ \t]+", " ", normalized)
         normalized = re.sub(r"\n{3,}", "\n\n", normalized)


### PR DESCRIPTION
…ness

- _extract_names: require min 2 words (not 1), reject len<4 names unconditionally, sort tiebreaker -len so LONGER names win when score tied (prevents single-char artifacts like 'e' from winning), score guard >0 before adding to candidates
- _looks_like_job_title: remove catch-all branch that returned True for any multi-word alphabetic string; now requires JOB_KEYWORD or long single word
- _extract_job_titles + _extract_companies: global fallback loop only runs when section-based extraction found nothing (avoids duplicate false positives)
- _extract_skills tokens: add xc0-xff so accented French words match token set
- _extract_locations: require both parts >=3 chars, reject language/edu keywords
- cv_extractor: use explicit _ZERO_WIDTH_CHARS constant instead of literal chars, add unconditional len<4 guard in _clean_name
- Fix all curly apostrophes -> ASCII in resume_ner_extractor.py (SyntaxError risk)