### PR TITLE
perf: singleton CVExtractionService + class-level HF pipeline cache

### DIFF
--- a/backend/ai_module/matching/semantic_matcher.py
+++ b/backend/ai_module/matching/semantic_matcher.py
@@ -54,7 +54,8 @@ class SemanticSkillMatcher:
         try:
             print(f"Loading {cls.MODEL_NAME}...")
             cls._model = SentenceTransformer(cls.MODEL_NAME)
-            print(f"✓ Model loaded successfully. Embedding dimension: {cls._model.get_sentence_embedding_dimension()}")
+            _get_dim = getattr(cls._model, "get_embedding_dimension", cls._model.get_sentence_embedding_dimension)
+            print(f"Loaded {cls.MODEL_NAME}. Embedding dimension: {_get_dim()}")
             return cls._model
         except Exception as e:
             print(f"Error loading model: {e}")

--- a/backend/ai_module/nlp/cv_parser.py
+++ b/backend/ai_module/nlp/cv_parser.py
@@ -25,23 +25,32 @@ class HFResumeNERParser:
     Recommended values:
     - dslim/bert-base-NER
     - Davlan/bert-base-multilingual-cased-ner-hrl
+
+    The underlying HF pipeline is cached at class level so that repeated
+    instantiation (e.g. once per upload request) does NOT reload weights
+    from disk each time.
     """
 
     EMAIL_RE = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
     PHONE_RE = re.compile(r"(?:\+?\d[\d\s().-]{7,}\d)")
 
+    # Class-level cache: keyed by model_name so that different model names
+    # can coexist without conflict.
+    _pipelines: Dict[str, object] = {}
+
     def __init__(self, model_name: str = "dslim/bert-base-NER") -> None:
         self.model_name = model_name
-        self.ner = None
-        if HF_NER_AVAILABLE:
+        # Return cached pipeline if already loaded for this model_name
+        if model_name not in HFResumeNERParser._pipelines and HF_NER_AVAILABLE:
             try:
-                self.ner = pipeline(
+                HFResumeNERParser._pipelines[model_name] = pipeline(
                     "ner",
-                    model=self.model_name,
+                    model=model_name,
                     aggregation_strategy="simple",
                 )
             except Exception:
-                self.ner = None
+                HFResumeNERParser._pipelines[model_name] = None
+        self.ner = HFResumeNERParser._pipelines.get(model_name)
 
     @property
     def available(self) -> bool:

--- a/backend/app/api/candidates.py
+++ b/backend/app/api/candidates.py
@@ -185,9 +185,9 @@ def get_my_candidate_profile(
 
     if needs_refresh:
         try:
-            from app.services.cv_extractor import CVExtractionService
+            from app.services.cv_extractor import get_cv_extraction_service
 
-            extraction_service = CVExtractionService()
+            extraction_service = get_cv_extraction_service()
             refreshed = extraction_service.extract_from_text(candidate.raw_text)
             refreshed_candidate = extraction_service.to_candidate_dict(refreshed)
 
@@ -353,10 +353,10 @@ async def upload_candidate_cv(
         if not extracted_text or not extracted_text.strip():
             extracted_text = f"Uploaded CV file: {Path(file_name).name}"
 
-        # NER extraction pipeline
-        from app.services.cv_extractor import CVExtractionService
+        # NER extraction pipeline — use singleton to avoid reloading BERT on every upload
+        from app.services.cv_extractor import get_cv_extraction_service
 
-        extraction_service = CVExtractionService()
+        extraction_service = get_cv_extraction_service()
         extraction_result = extraction_service.extract_from_text(extracted_text)
         candidate_dict = extraction_service.to_candidate_dict(extraction_result)
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -122,6 +122,11 @@ def on_startup():
     include_optional_router("app.api.admin", "router")
 
 
+@app.get("/")
+def root():
+    return {"status": "ok", "service": "AI Talent Finder"}
+
+
 # Health check endpoint (always available)
 @app.get("/health")
 def health():

--- a/backend/app/services/cv_extractor.py
+++ b/backend/app/services/cv_extractor.py
@@ -847,8 +847,23 @@ def save_text_as_txt(text: str, output_dir: str, base_name: str) -> str:
     return str(txt_path)
 
 
+# ---------------------------------------------------------------------------
+# Module-level singleton — BERT and embedding models are loaded once per
+# process. Calling CVExtractionService() on every request was reloading
+# 199 weight files each time (~3-5 s per upload).
+# ---------------------------------------------------------------------------
+_cv_extraction_service: Optional[CVExtractionService] = None
+
+
+def get_cv_extraction_service() -> CVExtractionService:
+    """Return the shared CVExtractionService instance, creating it if needed."""
+    global _cv_extraction_service
+    if _cv_extraction_service is None:
+        _cv_extraction_service = CVExtractionService()
+    return _cv_extraction_service
+
+
 # Convenience function for backward compatibility
 def extract_and_structure_cv(pdf_path: str) -> CVExtractionResult:
     """Extract CV and get complete structured data"""
-    service = CVExtractionService()
-    return service.extract_from_pdf(pdf_path)
+    return get_cv_extraction_service().extract_from_pdf(pdf_path)


### PR DESCRIPTION
BERT weights (dslim/bert-base-NER) were reloaded from disk on every upload request because CVExtractionService() was instantiated fresh each time. On 5 uploads that meant 5x "Loading weights: 100%" in logs.

Fixes:
- cv_extractor.py: module-level _cv_extraction_service singleton + get_cv_extraction_service() helper
- cv_parser.py: HFResumeNERParser._pipelines class-level dict so the HF pipeline is created once per model name, not once per instance
- candidates.py: replace CVExtractionService() calls with get_cv_extraction_service()
- semantic_matcher.py: use get_embedding_dimension() with fallback to suppress FutureWarning from deprecated get_sentence_embedding_dimension
- main.py: add GET / route (was returning 404 on every health poll)