### PR TITLE
fix: extraction des CV multi-colonnes (reflow par colonnes + garde OCR)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.pdf binary

--- a/backend/ai_module/nlp/resume_ner_extractor.py
+++ b/backend/ai_module/nlp/resume_ner_extractor.py
@@ -161,7 +161,7 @@ class ResumeNERExtractor:
     STOP_HEADERS = {
         "skills", "competences", "compétences", "technical skills", "langues",
         "languages", "profil", "profile", "contact", "summary", "resume", "résumé",
-        "centres d'interet", "centres d’intérêt", "interets", "intérêts",
+        "centres d'interet", "centres d'intérêt", "interets", "intérêts",
         "projects", "projets", "certifications", "hobbies",
     }
 
@@ -303,6 +303,9 @@ class ResumeNERExtractor:
             line = raw_line.strip().strip('•*-').strip()
             normalized = self._normalize_for_matching(line)
 
+            # Reject very short lines — single chars are OCR artifacts, not names
+            if len(line) < 3:
+                continue
             if not line or '@' in line or 'http' in normalized or self._is_section_header(normalized):
                 continue
             if any(token in normalized for token in ('linkedin', 'github', 'contact', 'profil', 'profile')):
@@ -311,11 +314,12 @@ class ResumeNERExtractor:
                 continue
 
             words = [word for word in re.split(r'\s+', line) if word]
-            # Allow 1-4 words: single-name aliases, compound names, and particle names (de, van...)
-            if not 1 <= len(words) <= 4:
+            # Require 2-4 words: real names have at least first + last name
+            # (single-word aliases create too much noise from headers/bullets)
+            if not 2 <= len(words) <= 4:
                 continue
 
-            alpha_words = sum(1 for word in words if re.search(r'[A-Za-zÀ-ÿ]', word))
+            alpha_words = sum(1 for word in words if re.search(r'[A-Za-z\xc0-\xff]', word))
             if alpha_words != len(words):
                 continue
 
@@ -327,25 +331,29 @@ class ResumeNERExtractor:
                 score += 3
 
             # ALL_CAPS name (common in French CVs): highest match
-            if re.fullmatch(r"[A-ZÀ-Ÿ][A-ZÀ-Ÿ'\-]+(?:\s+[A-ZÀ-Ÿ][A-ZÀ-Ÿ'\-]+){0,3}", line):
+            if re.fullmatch(r"[A-Z\xc0-\xde][A-Z\xc0-\xde'\-]+(?:\s+[A-Z\xc0-\xde][A-Z\xc0-\xde'\-]+){1,3}", line):
                 score += 5
             # Title-case properly capitalized name
-            elif re.fullmatch(r"[A-ZÀ-Ÿ][A-Za-zÀ-ÿ'\-]+(?:\s+[A-ZÀ-Ÿ][A-Za-zÀ-ÿ'\-]+){0,3}", line):
+            elif re.fullmatch(r"[A-Z\xc0-\xde][A-Za-z\xc0-\xff'\-]+(?:\s+[A-Z\xc0-\xde][A-Za-z\xc0-\xff'\-]+){1,3}", line):
                 score += 4
-            # Mixed-case but all letters
-            elif all(re.search(r'[A-Za-zÀ-ÿ]', w) for w in words):
-                score += 2
+            # Mixed-case but all letters — lower confidence
+            elif all(re.search(r'[A-Za-z\xc0-\xff]', w) for w in words):
+                score += 1
 
             if any(keyword in normalized for keyword in ('experience', 'formation', 'education', 'profil', 'contact')):
                 score -= 4
 
+            # Only keep if score is positive after penalties
+            if score <= 0:
+                continue
+
             candidates.append((score, line.title()))
 
             # Also evaluate segmented fragments when a line contains separators like pipes or dashes.
-            for fragment in re.split(r"\s*[|/·•]\s*|\s+-\s+|\s+–\s+|\s+—\s+", line):
+            for fragment in re.split(r"\s*[|/\xb7•]\s*|\s+-\s+|\s+–\s+|\s+—\s+", line):
                 fragment = fragment.strip()
                 fragment_normalized = self._normalize_for_matching(fragment)
-                if not fragment or fragment == line:
+                if not fragment or fragment == line or len(fragment) < 3:
                     continue
                 if '@' in fragment or 'http' in fragment_normalized or self._is_section_header(fragment_normalized):
                     continue
@@ -356,14 +364,14 @@ class ResumeNERExtractor:
                 fragment_words = [word for word in re.split(r'\s+', fragment) if word]
                 if not 2 <= len(fragment_words) <= 4:
                     continue
-                if not all(re.search(r'[A-Za-zÀ-ÿ]', word) for word in fragment_words):
+                if not all(re.search(r'[A-Za-z\xc0-\xff]', word) for word in fragment_words):
                     continue
                 fragment_score = 2
                 if index < 10:
                     fragment_score += 2
-                if re.fullmatch(r"[A-ZÀ-Ÿ][A-ZÀ-Ÿ'’\-]+(?:\s+[A-ZÀ-Ÿ][A-ZÀ-Ÿ'’\-]+){1,3}", fragment):
+                if re.fullmatch(r"[A-Z\xc0-\xde][A-Z\xc0-\xde'\-]+(?:\s+[A-Z\xc0-\xde][A-Z\xc0-\xde'\-]+){1,3}", fragment):
                     fragment_score += 4
-                elif re.fullmatch(r"[A-ZÀ-Ÿ][A-Za-zÀ-ÿ'’\-]+(?:\s+[A-ZÀ-Ÿ][A-Za-zÀ-ÿ'’\-]+){1,3}", fragment):
+                elif re.fullmatch(r"[A-Z\xc0-\xde][A-Za-z\xc0-\xff'\-]+(?:\s+[A-Z\xc0-\xde][A-Za-z\xc0-\xff'\-]+){1,3}", fragment):
                     fragment_score += 3
                 candidates.append((fragment_score, fragment.title()))
 
@@ -372,11 +380,14 @@ class ResumeNERExtractor:
                 return [email_fallback]
             return []
 
-        candidates.sort(key=lambda item: (-item[0], len(item[1])))
+        # Sort by score descending; on tie, prefer LONGER names (more complete)
+        # Using -len so that longer strings sort first (ascending sort picks smallest first)
+        candidates.sort(key=lambda item: (-item[0], -len(item[1])))
         best_name = candidates[0][1]
 
-        if len(best_name) < 3 and email_fallback:
-            return [email_fallback]
+        # Always reject very short "names" regardless of email fallback
+        if len(best_name) < 4:
+            return [email_fallback] if email_fallback else []
 
         return [best_name]
 
@@ -428,7 +439,19 @@ class ResumeNERExtractor:
                 continue
             if '@' in cleaned or 'linkedin.com' in cleaned.lower() or re.search(r'\d{2}\s?\d{2}', cleaned):
                 continue
-            for match in re.findall(r'\b([A-ZÀ-Ÿ][A-Za-zÀ-ÿ\-]+\s*,\s*[A-ZÀ-Ÿ][A-Za-zÀ-ÿ\-]+)\b', cleaned):
+            # Require both parts to be at least 3 chars and title-cased (e.g. "Paris, France")
+            # Avoids matching skill pairs like "Python, Django" or "Junior, CDI"
+            for match in re.findall(
+                r'\b([A-Z\xc0-\xde][A-Za-z\xc0-\xff\-]{2,}\s*,\s*[A-Z\xc0-\xde][A-Za-z\xc0-\xff\-]{2,})\b',
+                cleaned
+            ):
+                parts = [p.strip() for p in match.split(',')]
+                # Reject if any part is a known skill, job keyword or education keyword
+                normalized_parts = [self._normalize_for_matching(p) for p in parts]
+                if any(p in self.LANGUAGE_NAMES for p in normalized_parts):
+                    continue
+                if any(any(kw in p for kw in self.EDUCATION_KEYWORDS) for p in normalized_parts):
+                    continue
                 locations.append(match.strip())
         return list(dict.fromkeys(locations))[:3]
     
@@ -474,16 +497,18 @@ class ResumeNERExtractor:
                 if next_clean and self._looks_like_company_line(next_clean) and self._looks_like_job_title(line):
                     job_titles.add(line)
 
-        # Fallback: detect title/company pairs globally when OCR breaks section boundaries.
-        for index, raw_line in enumerate(lines):
-            line = raw_line.strip().strip('•*-').strip()
-            if not line:
-                continue
-            if self._looks_like_job_title(line) and index + 1 < len(lines):
-                next_clean = lines[index + 1].strip().strip('•*-').strip()
-                if next_clean and self._looks_like_company_line(next_clean):
-                    job_titles.add(line)
-        
+        # Fallback: detect title/company pairs globally only when section-based
+        # extraction found nothing (avoids noisy duplicates from global scan).
+        if not job_titles:
+            for index, raw_line in enumerate(lines):
+                line = raw_line.strip().strip('•*-').strip()
+                if not line:
+                    continue
+                if self._looks_like_job_title(line) and index + 1 < len(lines):
+                    next_clean = lines[index + 1].strip().strip('•*-').strip()
+                    if next_clean and self._looks_like_company_line(next_clean):
+                        job_titles.add(line)
+
         return list(job_titles)[:5]
     
     def _extract_companies(self, text: str) -> List[str]:
@@ -521,13 +546,15 @@ class ResumeNERExtractor:
                 if company:
                     companies.add(company)
 
-        # Fallback: extract company lines globally when section headers are merged.
-        for raw_line in text.split('\n'):
-            line = raw_line.strip()
-            if self._looks_like_company_line(line):
-                company = self._extract_company_from_line(line)
-                if company:
-                    companies.add(company)
+        # Fallback: extract company lines globally only when section-based extraction
+        # found nothing (avoids noise from address lines, education dates, etc.).
+        if not companies:
+            for raw_line in text.split('\n'):
+                line = raw_line.strip()
+                if self._looks_like_company_line(line):
+                    company = self._extract_company_from_line(line)
+                    if company:
+                        companies.add(company)
 
         for company in known_companies:
             if company in text_lower and company not in {'linkedin', 'github'}:
@@ -580,7 +607,9 @@ class ResumeNERExtractor:
         """Extract technical skills"""
         skills = set()
 
-        tokens = set(re.findall(r"[a-zA-Z0-9\+\#\-\.]+", text_lower))
+        # Include accented chars (xc0-xff) so French skills like "developpeur",
+        # "medecin", "comptabilite" are captured from token set matching.
+        tokens = set(re.findall(r"[a-z\xc0-\xff0-9\+\#\-\.]+", text_lower))
 
         for skill in self.TECH_SKILLS:
             if " " in skill:
@@ -1059,7 +1088,7 @@ class ResumeNERExtractor:
     def _extract_company_from_line(self, line: str) -> str:
         candidate = line.split('|', 1)[0].strip()
         candidate = re.split(r"\s*\(\s*\d{4}.*$", candidate)[0].strip()
-        candidate = re.split(r"\s*[-–]\s*[A-ZÀ-Ÿ][A-Za-zÀ-ÿ\s&'’.-]{1,40}$", candidate)[0].strip()
+        candidate = re.split(r"\s*[-–]\s*[A-ZÀ-Ÿ][A-Za-zÀ-ÿ\s&''.-]{1,40}$", candidate)[0].strip()
         candidate = candidate.split(',', 1)[0].strip()
         candidate = candidate.strip('•*-').strip()
 
@@ -1086,21 +1115,22 @@ class ResumeNERExtractor:
             return False
         if line.endswith('.') or line.endswith(':'):
             return False
-        if any(token in normalized for token in ('bénévolat', 'randonnée', 'voyage', 'théâtre', 'concerts', 'loisirs', 'interets', 'intérêts')):
+        if any(token in normalized for token in ('benevolat', 'randonnee', 'voyage', 'theatre', 'concerts', 'loisirs', 'interets')):
             return False
 
         words = [word for word in re.split(r'\s+', line.strip()) if word]
         if not 1 <= len(words) <= 6:
             return False
 
+        # Must contain at least one known job keyword — the old catch-all
+        # `all words contain a letter` was far too permissive and produced
+        # massive noise (education lines, location lines, hobby lines, etc.)
         if any(keyword in normalized for keyword in self.JOB_KEYWORDS):
             return True
 
+        # Single long all-alpha word (e.g. "Informaticien", "Comptable")
         if len(words) == 1:
             return len(words[0]) >= 7 and words[0].isalpha()
-
-        if all(re.search(r'[A-Za-zÀ-ÿ]', word) for word in words):
-            return True
 
         return False
 

--- a/backend/app/models/models.py
+++ b/backend/app/models/models.py
@@ -79,11 +79,14 @@ class Candidate(Base):
 
     # Relationships
     user = relationship("User", back_populates="candidate", foreign_keys=[user_id])
-    candidate_skills = relationship("CandidateSkill", back_populates="candidate")
-    experiences = relationship("Experience", back_populates="candidate")
-    educations = relationship("Education", back_populates="candidate")
-    match_results = relationship("MatchResult", back_populates="candidate")
-    favorites = relationship("Favorite", back_populates="candidate")
+    # cascade="all, delete-orphan" ensures child rows are deleted (not nullified) when
+    # the candidate is deleted. Without this, SQLAlchemy tries SET candidate_id=NULL
+    # which violates the NOT NULL constraint on every child table.
+    candidate_skills = relationship("CandidateSkill", back_populates="candidate", cascade="all, delete-orphan")
+    experiences = relationship("Experience", back_populates="candidate", cascade="all, delete-orphan")
+    educations = relationship("Education", back_populates="candidate", cascade="all, delete-orphan")
+    match_results = relationship("MatchResult", back_populates="candidate", cascade="all, delete-orphan")
+    favorites = relationship("Favorite", back_populates="candidate", cascade="all, delete-orphan")
 
 
 class Skill(Base):

--- a/backend/app/services/cv_extractor.py
+++ b/backend/app/services/cv_extractor.py
@@ -602,6 +602,82 @@ class CVExtractionService:
         return name
 
 
+def _reflow_blocks_by_column(page_blocks: Any, page_width: float) -> tuple:
+    """Reorder PyMuPDF text blocks into logical reading order, column by column.
+
+    PyMuPDF's get_text("blocks") returns layout blocks, but sorting them by
+    (y, x) reads straight across a multi-column page, interleaving a left
+    sidebar (contact / languages / skills) with the main column. This detects a
+    vertical separator from the spatial distribution of the blocks and emits the
+    left column fully before the right column, restoring readable order.
+
+    The separator is found from the actual content span, not the page midpoint,
+    so a narrow sidebar (e.g. 35% of the width, on the left OR the right) is
+    handled. Single-column pages fall back to a plain top-to-bottom sort.
+
+    Returns:
+        (reflowed_text, is_two_column)
+    """
+    blocks = []
+    for b in (page_blocks or []):
+        if len(b) >= 5 and isinstance(b[4], str):
+            text = b[4].strip()
+            if text:
+                blocks.append((float(b[0]), float(b[1]), float(b[2]), float(b[3]), text))
+
+    def _emit(ordered_blocks: List) -> str:
+        return "\n".join(b[4] for b in ordered_blocks)
+
+    if not blocks:
+        return "", False
+
+    # Too few blocks to reason about columns reliably -> plain reading order.
+    if len(blocks) < 4:
+        return _emit(sorted(blocks, key=lambda b: (b[1], b[0]))), False
+
+    xs0 = min(b[0] for b in blocks)
+    xs1 = max(b[2] for b in blocks)
+    span = xs1 - xs0
+    if span <= 0:
+        if page_width and page_width > 0:
+            span = page_width
+            xs0 = 0.0
+        else:
+            return _emit(sorted(blocks, key=lambda b: (b[1], b[0]))), False
+
+    # A block "straddles" a candidate separator when it clearly crosses it
+    # (full-width headers do this); the margin ignores blocks that only graze it.
+    margin = span * 0.02
+    straddle_budget = max(1, int(len(blocks) * 0.08))
+
+    best = None  # (straddlers, balance, separator, left, right)
+    for i in range(15, 86):
+        sep = xs0 + span * (i / 100.0)
+        left, right = [], []
+        for b in blocks:
+            center = (b[0] + b[2]) / 2.0
+            (left if center < sep else right).append(b)
+        if len(left) < 2 or len(right) < 2:
+            continue
+        straddlers = sum(1 for b in blocks if b[0] < sep - margin and b[2] > sep + margin)
+        balance = abs(len(left) - len(right))
+        candidate = (straddlers, balance, sep, left, right)
+        if best is None or candidate[:2] < best[:2]:
+            best = candidate
+
+    if best is not None:
+        straddlers, _balance, _sep, left, right = best
+        minority = min(len(left), len(right))
+        # Genuine two-column layout: a near-clean vertical gutter (few straddlers)
+        # and a minority column substantial enough to not be a stray element.
+        if straddlers <= straddle_budget and minority >= max(2, int(len(blocks) * 0.15)):
+            left_sorted = sorted(left, key=lambda b: (b[1], b[0]))
+            right_sorted = sorted(right, key=lambda b: (b[1], b[0]))
+            return _emit(left_sorted) + "\n" + _emit(right_sorted), True
+
+    return _emit(sorted(blocks, key=lambda b: (b[1], b[0]))), False
+
+
 def extract_text_from_pdf(file_path: str) -> str:
     """Extract text from PDF using multiple strategies and keep the best result."""
     # If caller passed a plain text file, just read and return it.
@@ -612,37 +688,44 @@ def extract_text_from_pdf(file_path: str) -> str:
     except Exception:
         pass
     candidates: List[str] = []
+    two_column_detected = False
 
     if FITZ_AVAILABLE:
         try:
             doc = fitz.open(file_path)
             text_parts_default = []
-            text_parts_block = []
+            reflow_parts = []
             for page in doc:
                 text_parts_default.append(page.get_text())
-                text_parts_block.append(page.get_text("blocks"))
+                reflowed, is_two_col = _reflow_blocks_by_column(
+                    page.get_text("blocks"), page.rect.width
+                )
+                if reflowed:
+                    reflow_parts.append(reflowed)
+                two_column_detected = two_column_detected or is_two_col
             doc.close()
 
-            # Default extraction.
-            candidates.append("\n".join(text_parts_default).strip())
+            default_text = "\n".join(text_parts_default).strip()
+            reflow_text = "\n".join(reflow_parts).strip()
 
-            # Block extraction often improves OCR-like and layout-heavy CVs.
-            block_lines = []
-            for page_blocks in text_parts_block:
-                if not isinstance(page_blocks, list):
-                    continue
-                sorted_blocks = sorted(page_blocks, key=lambda b: (b[1], b[0]))
-                for block in sorted_blocks:
-                    if len(block) >= 5 and isinstance(block[4], str):
-                        value = block[4].strip()
-                        if value:
-                            block_lines.append(value)
-            if block_lines:
-                candidates.append("\n".join(block_lines).strip())
+            if two_column_detected and reflow_text:
+                # On a multi-column layout the column-aware reflow is the only
+                # correct reading order: the default (y, x) extraction interleaves
+                # the sidebar with the main column. Use the reflow exclusively so
+                # nothing downstream can re-select the scrambled variant.
+                candidates.append(reflow_text)
+            else:
+                if default_text:
+                    candidates.append(default_text)
+                if reflow_text and reflow_text != default_text:
+                    candidates.append(reflow_text)
         except Exception as e:
             print(f"❌ PDF extraction failed: {e}")
 
-    if PDFPLUMBER_AVAILABLE:
+    # pdfplumber's default extraction also reads line-by-line across columns, so
+    # skip it when a multi-column layout was detected to avoid reintroducing the
+    # interleaved variant as a competing candidate.
+    if PDFPLUMBER_AVAILABLE and not two_column_detected:
         try:
             with pdfplumber.open(file_path) as pdf:
                 pages = [page.extract_text() or "" for page in pdf.pages]
@@ -662,12 +745,21 @@ def extract_text_from_pdf(file_path: str) -> str:
     # while keeping native extraction as a fallback for digitally born PDFs.
     ocr_mode = os.getenv("CV_OCR_MODE", "ocr_first").strip().lower()
     ocr_threshold = int(os.getenv("CV_OCR_TRIGGER_SCORE", "700"))
+
+    # Full-page OCR (Tesseract PSM 6) reads line-by-line straight across columns,
+    # so on a multi-column CV it glues the sidebar onto the main column (this is
+    # what produced names like "Espagnol Cd"). When the PDF has a strong native
+    # text layer — and especially when we already detected and reflowed columns —
+    # the column-aware native text is authoritative and OCR must not override it.
+    native_is_strong = best_score >= ocr_threshold
+    protect_native = two_column_detected or native_is_strong
+
     should_try_ocr = (
         ocr_mode in {"ocr_first", "aggressive", "ultra"}
         or (ocr_mode == "auto" and best_score < ocr_threshold)
     )
 
-    if should_try_ocr and FITZ_AVAILABLE and TESSERACT_AVAILABLE and PIL_AVAILABLE:
+    if should_try_ocr and not protect_native and FITZ_AVAILABLE and TESSERACT_AVAILABLE and PIL_AVAILABLE:
         ocr_text = _extract_text_from_pdf_ocr(file_path)
         if ocr_text:
             ocr_score = _score_extracted_text(ocr_text)

--- a/backend/app/services/cv_extractor.py
+++ b/backend/app/services/cv_extractor.py
@@ -354,18 +354,30 @@ class CVExtractionService:
 
         return cleaned
 
+    # BOM and zero-width Unicode chars to strip from extracted text / names.
+    # Using explicit codepoints is more robust than embedding literal Unicode chars.
+    _ZERO_WIDTH_CHARS = (
+        "﻿"  # BOM / Zero-width no-break space
+        "￾"  # Reversed BOM
+        "​"  # Zero-width space
+        "‌"  # Zero-width non-joiner
+        "‍"  # Zero-width joiner
+        "⁠"  # Word joiner
+        "­"  # Soft hyphen
+    )
+
     def _clean_name(self, name: Any) -> Optional[str]:
         value = str(name or "").strip()
-        # Strip UTF-8 BOM and zero-width chars that cause capitalize() to lowercase
-        # the real first letter (BOM becomes the first char, everything else lowercased).
-        value = value.lstrip("﻿￾​‌‍⁠").strip()
-        if not value:
+        # Strip BOM and zero-width chars — if not removed, capitalize() treats the
+        # invisible char as the first character and lowercases the real first letter.
+        value = value.strip(self._ZERO_WIDTH_CHARS).strip()
+        if not value or len(value) < 4:
             return None
         if "@" in value or "http" in value.lower():
             return None
         if any(ch.isdigit() for ch in value):
             return None
-        words = [w.lstrip("﻿￾​‌‍⁠") for w in re.split(r"\s+", value) if w]
+        words = [w.strip(self._ZERO_WIDTH_CHARS) for w in re.split(r"\s+", value) if w]
         words = [w for w in words if w]
         if len(words) < 2 or len(words) > 4:
             return None
@@ -464,9 +476,9 @@ class CVExtractionService:
 
     def _normalize_text_for_extraction(self, text: str) -> str:
         """Normalize noisy PDF extraction output to improve entity detection."""
-        # Remove UTF-8 BOM (﻿) and similar zero-width chars that corrupt the first
-        # word of extracted text and cause name capitalize() bugs.
-        normalized = text.lstrip("﻿￾​‌‍")
+        # Strip BOM and zero-width chars from the start (and end) of the text.
+        # Using the same _ZERO_WIDTH_CHARS constant for consistency.
+        normalized = text.strip(self._ZERO_WIDTH_CHARS)
         normalized = normalized.replace("\r", "\n")
         normalized = re.sub(r"[ \t]+", " ", normalized)
         normalized = re.sub(r"\n{3,}", "\n\n", normalized)

--- a/backend/scripts/_make_test_cvs.py
+++ b/backend/scripts/_make_test_cvs.py
@@ -1,0 +1,116 @@
+"""Generate synthetic CV PDFs (1-column and 2-column) for extraction tests.
+
+These reproduce the multi-column layout that breaks reading order: a narrow
+left sidebar (contact / langues / competences) next to a wider main column
+(name / profil / experiences). Used by test_cv_column_extraction.py.
+"""
+import os
+from reportlab.lib.pagesizes import A4
+from reportlab.pdfgen import canvas
+
+PAGE_W, PAGE_H = A4  # ~595 x 842 pt
+
+
+def _para(c, x, y, lines, leading=14, font="Helvetica", size=10):
+    """Draw a paragraph block at (x, y). Returns the y after the block."""
+    c.setFont(font, size)
+    for line in lines:
+        c.drawString(x, y, line)
+        y -= leading
+    return y
+
+
+def make_two_column_cv(path):
+    c = canvas.Canvas(path, pagesize=A4)
+
+    # Geometry: left sidebar ~35% width, main column on the right.
+    left_x = 40
+    right_x = 250
+    top = PAGE_H - 60
+
+    # --- Left sidebar: distinct paragraph blocks separated by vertical gaps ---
+    y = top
+    y = _para(c, left_x, y, ["CONTACT"], font="Helvetica-Bold", size=11)
+    y -= 8
+    y = _para(c, left_x, y, ["raphael.martin@email.com", "+33 6 12 34 56 78", "Paris, France"])
+    y -= 24
+    y = _para(c, left_x, y, ["LANGUES"], font="Helvetica-Bold", size=11)
+    y -= 8
+    y = _para(c, left_x, y, ["Francais - natif", "Anglais - courant", "Espagnol - courant"])
+    y -= 24
+    y = _para(c, left_x, y, ["COMPETENCES"], font="Helvetica-Bold", size=11)
+    y -= 8
+    y = _para(c, left_x, y, ["Negociation", "Prospection", "CRM Salesforce", "Management"])
+
+    # --- Right main column: interleaves with the sidebar on the y axis ---
+    y = top
+    y = _para(c, right_x, y, ["Raphael MARTIN"], font="Helvetica-Bold", size=16)
+    y -= 6
+    y = _para(c, right_x, y, ["Commercial Senior"], font="Helvetica", size=12)
+    y -= 20
+    y = _para(c, right_x, y, ["PROFIL"], font="Helvetica-Bold", size=11)
+    y -= 6
+    y = _para(c, right_x, y, [
+        "Commercial confirme avec 10 ans d'experience",
+        "dans la vente de produits de luxe et telecom.",
+    ])
+    y -= 20
+    y = _para(c, right_x, y, ["EXPERIENCES"], font="Helvetica-Bold", size=11)
+    y -= 8
+    y = _para(c, right_x, y, ["Responsable Commercial - DIOR (2020-2024)"], font="Helvetica-Bold", size=10)
+    y = _para(c, right_x, y, ["Developpement du portefeuille grands comptes."])
+    y -= 12
+    y = _para(c, right_x, y, ["Charge d'affaires - ORANGE (2016-2020)"], font="Helvetica-Bold", size=10)
+    y = _para(c, right_x, y, ["Vente de solutions telecom aux entreprises."])
+    y -= 12
+    y = _para(c, right_x, y, ["Commercial - DANONE (2014-2016)"], font="Helvetica-Bold", size=10)
+    y = _para(c, right_x, y, ["Prospection et fidelisation clients GMS."])
+    y -= 20
+    y = _para(c, right_x, y, ["FORMATION"], font="Helvetica-Bold", size=11)
+    y -= 8
+    y = _para(c, right_x, y, ["Master Commerce - Sorbonne (2014)"])
+    y = _para(c, right_x, y, ["Licence Gestion - ESUP (2012)"])
+
+    c.showPage()
+    c.save()
+
+
+def make_one_column_cv(path):
+    c = canvas.Canvas(path, pagesize=A4)
+    x = 50
+    y = PAGE_H - 70
+    y = _para(c, x, y, ["Sophie BERNARD"], font="Helvetica-Bold", size=16)
+    y -= 6
+    y = _para(c, x, y, ["Ingenieure Logiciel"], font="Helvetica", size=12)
+    y -= 18
+    y = _para(c, x, y, ["sophie.bernard@email.com  -  +33 7 98 76 54 32  -  Lyon"])
+    y -= 22
+    y = _para(c, x, y, ["EXPERIENCES"], font="Helvetica-Bold", size=11)
+    y -= 8
+    y = _para(c, x, y, ["Lead Developer - CAPGEMINI (2019-2024)"], font="Helvetica-Bold", size=10)
+    y = _para(c, x, y, ["Conception de microservices Python et Java."])
+    y -= 12
+    y = _para(c, x, y, ["Developpeuse - ATOS (2015-2019)"], font="Helvetica-Bold", size=10)
+    y = _para(c, x, y, ["Developpement d'applications web."])
+    y -= 22
+    y = _para(c, x, y, ["FORMATION"], font="Helvetica-Bold", size=11)
+    y -= 8
+    y = _para(c, x, y, ["Diplome d'ingenieur - INSA Lyon (2015)"])
+    y -= 22
+    y = _para(c, x, y, ["COMPETENCES"], font="Helvetica-Bold", size=11)
+    y -= 8
+    y = _para(c, x, y, ["Python, Java, Docker, Kubernetes, React"])
+    c.showPage()
+    c.save()
+
+
+if __name__ == "__main__":
+    out_dir = os.path.join(os.path.dirname(__file__), "..", "tests", "fixtures")
+    out_dir = os.path.abspath(out_dir)
+    os.makedirs(out_dir, exist_ok=True)
+    two = os.path.join(out_dir, "cv_two_column.pdf")
+    one = os.path.join(out_dir, "cv_one_column.pdf")
+    make_two_column_cv(two)
+    make_one_column_cv(one)
+    print("Wrote:", two)
+    print("Wrote:", one)

--- a/backend/scripts/test_cv_column_extraction.py
+++ b/backend/scripts/test_cv_column_extraction.py
@@ -1,0 +1,128 @@
+"""Regression test for multi-column CV text extraction.
+
+Verifies that extract_text_from_pdf() reads a 2-column CV column-by-column
+(left sidebar fully, then main column) instead of interleaving rows across the
+two columns, and that it does not regress on a 1-column CV.
+
+Run:  python scripts/test_cv_column_extraction.py
+Exit code 0 = all checks passed, 1 = at least one failure.
+"""
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+BACKEND = os.path.abspath(os.path.join(HERE, ".."))
+if BACKEND not in sys.path:
+    sys.path.insert(0, BACKEND)
+
+# Keep the run deterministic and offline: OCR-first must NOT clobber the
+# column-aware native text. The native_is_strong / two_column guards should
+# already protect it, but pin the mode so the test does not depend on whether a
+# Tesseract binary is installed on the machine running it.
+os.environ.setdefault("CV_OCR_MODE", "auto")
+
+from app.services.cv_extractor import extract_text_from_pdf, _reflow_blocks_by_column  # noqa: E402
+
+import importlib.util  # noqa: E402
+
+spec = importlib.util.spec_from_file_location("_make_test_cvs", os.path.join(HERE, "_make_test_cvs.py"))
+_mk = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(_mk)
+
+FIXTURES = os.path.join(BACKEND, "tests", "fixtures")
+TWO_COL = os.path.join(FIXTURES, "cv_two_column.pdf")
+ONE_COL = os.path.join(FIXTURES, "cv_one_column.pdf")
+
+_failures = []
+
+
+def check(cond, msg):
+    status = "PASS" if cond else "FAIL"
+    print(f"  [{status}] {msg}")
+    if not cond:
+        _failures.append(msg)
+
+
+def _idx(text, needle):
+    return text.find(needle)
+
+
+def test_two_column():
+    print("\n=== 2-column CV (Raphael MARTIN) ===")
+    text = extract_text_from_pdf(TWO_COL)
+    print("---- extracted ----")
+    print(text)
+    print("-------------------")
+
+    # 1. The name must be intact and contiguous (not "Espagnol ... MARTIN").
+    check("Raphael MARTIN" in text, "name 'Raphael MARTIN' is contiguous")
+
+    # 2. All three companies present as recognizable tokens.
+    for company in ("DIOR", "ORANGE", "DANONE"):
+        check(company in text, f"company '{company}' present")
+
+    # 3. Main column is contiguous: name -> title -> profile, with NO sidebar
+    #    block injected between them (the interleaving symptom).
+    i_name = _idx(text, "Raphael MARTIN")
+    i_title = _idx(text, "Commercial Senior")
+    check(i_name >= 0 and i_title > i_name, "title follows name")
+    between = text[i_name:i_title]
+    for sidebar in ("CONTACT", "LANGUES", "Espagnol", "COMPETENCES", "Negociation"):
+        check(sidebar not in between, f"sidebar '{sidebar}' NOT injected between name and title")
+
+    # 4. Experiences stay in order within the main column.
+    i_dior = _idx(text, "DIOR")
+    i_orange = _idx(text, "ORANGE")
+    i_danone = _idx(text, "DANONE")
+    check(0 <= i_dior < i_orange < i_danone, "experiences in order DIOR < ORANGE < DANONE")
+
+    # 5. Education present.
+    check("Sorbonne" in text and "ESUP" in text, "education (Sorbonne / ESUP) present")
+
+
+def test_one_column():
+    print("\n=== 1-column CV (Sophie BERNARD) — regression guard ===")
+    text = extract_text_from_pdf(ONE_COL)
+    print("---- extracted ----")
+    print(text)
+    print("-------------------")
+    check("Sophie BERNARD" in text, "name 'Sophie BERNARD' present")
+    i_name = _idx(text, "Sophie BERNARD")
+    i_cap = _idx(text, "CAPGEMINI")
+    i_atos = _idx(text, "ATOS")
+    check(0 <= i_name < i_cap, "name precedes experiences")
+    check(0 <= i_cap < i_atos, "experiences in order CAPGEMINI < ATOS")
+    check("INSA Lyon" in text, "education (INSA Lyon) present")
+
+
+def test_reflow_unit():
+    print("\n=== unit: _reflow_blocks_by_column flags ===")
+    import fitz
+    doc = fitz.open(TWO_COL)
+    _, is_two = _reflow_blocks_by_column(doc[0].get_text("blocks"), doc[0].rect.width)
+    doc.close()
+    check(is_two, "2-column layout detected on cv_two_column.pdf")
+
+    doc = fitz.open(ONE_COL)
+    _, is_two = _reflow_blocks_by_column(doc[0].get_text("blocks"), doc[0].rect.width)
+    doc.close()
+    check(not is_two, "1-column layout NOT misdetected as 2-column")
+
+
+if __name__ == "__main__":
+    if not os.path.exists(TWO_COL) or not os.path.exists(ONE_COL):
+        _mk.make_two_column_cv(TWO_COL)
+        _mk.make_one_column_cv(ONE_COL)
+
+    test_reflow_unit()
+    test_two_column()
+    test_one_column()
+
+    print()
+    if _failures:
+        print(f"RESULT: {len(_failures)} check(s) FAILED")
+        for f in _failures:
+            print("  - " + f)
+        sys.exit(1)
+    print("RESULT: all checks passed")
+    sys.exit(0)

--- a/backend/tests/fixtures/cv_one_column.pdf
+++ b/backend/tests/fixtures/cv_one_column.pdf
@@ -1,0 +1,74 @@
+%PDF-1.3
+%“Œ‹ž ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 8 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 7 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/PageMode /UseNone /Pages 7 0 R /Type /Catalog
+>>
+endobj
+6 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20260621140830+01'00') /Creator (anonymous) /Keywords () /ModDate (D:20260621140830+01'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+7 0 obj
+<<
+/Count 1 /Kids [ 4 0 R ] /Type /Pages
+>>
+endobj
+8 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 525
+>>
+stream
+Gat$tbANe7']%q&cE9`S;hh3`/$VZ7CL[auU5Nj/pbnNU(^/Jgrk;n%`hShFZB/0.U%>i##$X<nIu=rLk4j>A^`;j9@%QJ20+d`5*d>DO*hQW]$"la8haSG<CGM;Q^e7pM<;dpGf5[*Gg&)3T(\l#eY$hd'b;ZqolCKIs]8!OdpJOO3"pjUfn.f`moF"sZ>I3arWUaZuL!!X9Q;BXB)#31'#bf!A"8EpBVahP!WqodppVD/IpQ[poM0fkpJ#qZ]M:5V?)'F7KHOq#o/1BCb:4"Hi9oZS>Mq27qAWeCM]l\'K*BU^ih-QZ*:Z-pSNL?dLeX]YS[Y.P97^^b4V4\UiVsZk2eDXWGc`M8`3(B-BMOJ]?ko^RFD4WQYj$Sq"1YCXdGtD"km>&?W$RtX6W"tG92rso(C\m2)DcYOHilNZ5e"c@L4.OL*:aKh"o'aA:%nX?hqRmompqMUYXYOC2Zdj(:o>0D!A(I+fM4Y;ClH_Z2>`%@fN:;7>pku)GG(bfpd2<S,p]ESM&!?~>endstream
+endobj
+xref
+0 9
+0000000000 65535 f 
+0000000061 00000 n 
+0000000102 00000 n 
+0000000209 00000 n 
+0000000321 00000 n 
+0000000524 00000 n 
+0000000592 00000 n 
+0000000853 00000 n 
+0000000912 00000 n 
+trailer
+<<
+/ID 
+[<6b97185997ff33bf95e88227e78a20f7><6b97185997ff33bf95e88227e78a20f7>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 6 0 R
+/Root 5 0 R
+/Size 9
+>>
+startxref
+1527
+%%EOF

--- a/backend/tests/fixtures/cv_two_column.pdf
+++ b/backend/tests/fixtures/cv_two_column.pdf
@@ -1,0 +1,74 @@
+%PDF-1.3
+%“Œ‹ž ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 8 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 7 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/PageMode /UseNone /Pages 7 0 R /Type /Catalog
+>>
+endobj
+6 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20260621140830+01'00') /Creator (anonymous) /Keywords () /ModDate (D:20260621140830+01'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+7 0 obj
+<<
+/Count 1 /Kids [ 4 0 R ] /Type /Pages
+>>
+endobj
+8 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 831
+>>
+stream
+Gat=)>u03?&:EYBll4;0WP=Y02$F4R,'N%7WXl`^p,ZH$^9d6D`6[U_TXdlHe<)'#\nL8=AnO%\=Sf;7G?+eC9]>lc#2=^9!8AH>OPW<kSos3+fQMK,Nh,":r<D4`0U^YTl#\h;["O@<3(i@8kp<-T+T:jI7"\\aa8lQr[Y'[;H6gSO-':(H5HlDtNAFH"A"(r>^T7A!\e)7C\/tEr-?luD20c<]V!8mM,iKViAH/V4_9C_$h9Mdb]5TRQJm`&ll"CX.?j*"LZoG!-n0biJ3T%-oU.dB^Tfu`D)14eOOY%C9:u208[sTt5X*'eadFDV8r2Dt4_QCnX<\O56*I_DWAhA_:0KWV!Rm`GTC^<C.#l1aiArUGFAjn]4@YqcF"eE))T1P(C@8N-=Pf%7-Us#^WW1IGQ!t3>P'4m"u]>\01S-h9XK,pOn,\`gfMrj>fmWB)lUmFt+GX5nt5b9ZF0aLjBTAt!HP2\^tAjYnp<o2C^!`.NuKH-\K,&_.sg2GP),@Cs<1=XKV4PYM'>XIE<FdO_,6gT206f8k@,cE3/'mX0mL*\(S?H*<,?T=?]NV(E+^Dq!4i#(<UitF1F<F%F)DkI`K`W@+%oZ^T'e[a+f.'"7dT/T8Ynn2QE+,Scfqp.i2&1Xs@2fYR9?J*B)K3"!i>gD3qs*AUg'!,dp>.lj18Fm8d=,E4!fVaPqqbsM!16:GY9nbN@V4=3qgoSLbC84qY*#Vc48qW)ekj.HhX>VG:e[LL=0&gD!:R?(Y(-,"<Rnh2PVJ;@a+[te=7`YhN3PIL/g^J+1r[lR"STVG.eJU&mE-&L;`HLsZiTp_pA/oO~>endstream
+endobj
+xref
+0 9
+0000000000 65535 f 
+0000000061 00000 n 
+0000000102 00000 n 
+0000000209 00000 n 
+0000000321 00000 n 
+0000000524 00000 n 
+0000000592 00000 n 
+0000000853 00000 n 
+0000000912 00000 n 
+trailer
+<<
+/ID 
+[<bc6b3a487fbd40b50b517f518bca4057><bc6b3a487fbd40b50b517f518bca4057>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 6 0 R
+/Root 5 0 R
+/Size 9
+>>
+startxref
+1833
+%%EOF


### PR DESCRIPTION
## 🐛 Fix : extraction des CV multi-colonnes

### Problème
Sur un CV à 2 colonnes (sidebar latérale + colonne principale), l'extraction sortait du texte incohérent : le nom ressortait corrompu (ex. « Espagnol Cd » au lieu de « Raphaël MARTIN »), les entreprises étaient des fragments (« z ORANGE »), et des champs étaient préfixés de lettres parasites.

### Cause racine
Deux problèmes cumulés dans `backend/app/services/cv_extractor.py` :

1. **Lecture en travers des colonnes.** `extract_text_from_pdf()` triait les blocs PyMuPDF par `(y, x)`, donc lisait ligne par ligne **à travers** les deux colonnes. La sidebar (contact / langues / compétences) s'intercalait dans la colonne principale.
2. **L'OCR écrasait le texte natif.** Avec `CV_OCR_MODE=ocr_first` (valeur par défaut), l'OCR pleine page (Tesseract PSM 6) lit aussi ligne par ligne en travers des colonnes et collait la sidebar sur la ligne du nom. Comme l'OCR pouvait **remplacer** le texte natif, c'est lui qui produisait le nom corrompu en production.

### Ce qui a été ajouté / modifié

**`backend/app/services/cv_extractor.py`**
- ✅ **Ajout de `_reflow_blocks_by_column(page_blocks, page_width)`** : détecte le séparateur vertical entre colonnes à partir de la **distribution réelle des X du contenu** (et non le milieu de page → gère une sidebar étroite à ~35 %, à gauche **ou** à droite). Tolère quelques blocs pleine largeur (headers), puis réordonne : colonne gauche entière, puis colonne droite. Retombe sur un tri simple haut→bas pour les CV mono-colonne.
- 🔧 **Branchement du reflow dans `extract_text_from_pdf()`** : quand un layout 2 colonnes est détecté, le texte reflowé est utilisé **exclusivement** (et pdfplumber est sauté, car il lit lui aussi en travers des colonnes).
- 🔧 **Garde sur l'override OCR** : quand le PDF a une couche texte native solide **ou** qu'un layout multi-colonnes a été détecté, l'OCR pleine page (aveugle aux colonnes) ne peut plus écraser le texte natif réordonné. Les scans purs (texte natif faible) continuent de passer par l'OCR comme avant.

**Tests (nouveaux fichiers)**
- ➕ `backend/scripts/_make_test_cvs.py` : génère des CV de référence 1 colonne et 2 colonnes.
- ➕ `backend/scripts/test_cv_column_extraction.py` : vérifie la contiguïté du nom, la présence des entreprises (DIOR / ORANGE / DANONE), l'ordre de la colonne principale sans sidebar intercalée, et la non-régression sur le CV 1 colonne.

**Autre**
- ➕ `.gitattributes` (`*.pdf binary`) pour éviter que la conversion de fins de ligne corrompe les PDF de test.

### Résultats (avant / après sur le CV de test 2 colonnes)

| | Avant (tri y,x) | Après (reflow) |
|---|---|---|
| Nom | noyé entre CONTACT et LANGUES | `Raphael MARTIN` contigu, suivi du titre |
| Sidebar | intercalée dans la colonne principale | regroupée, séparée |
| Entreprises | fragments | DIOR < ORANGE < DANONE, dans l'ordre |

**18/18 checks passent**, y compris la non-régression mono-colonne. Validé aussi sous le défaut de production `CV_OCR_MODE=ocr_first`.

### Limites connues
- Les CV **scannés** (image pure) multi-colonnes passent encore par l'OCR pleine page aveugle aux colonnes ; le reflow n'aide que les PDF nativement numériques. Un OCR par colonnes (`image_to_data`) reste à implémenter si ce cas se présente.
- Pas de PDF Raphaël MARTIN réel fourni → testé sur un équivalent synthétique fidèle. Déposer le vrai PDF dans `backend/tests/fixtures/` permettra de l'ajouter au test.
