### PR TITLE
feat: integrate GLiNER as principal NER extractor with regex/BERT fal…

### DIFF
--- a/backend/ai_module/nlp/gliner_extractor.py
+++ b/backend/ai_module/nlp/gliner_extractor.py
@@ -1,0 +1,241 @@
+"""GLiNER-based CV entity extractor.
+
+Uses urchade/gliner_multi-v2.1 as the principal NER layer for high-precision
+extraction of person names, companies, schools and job titles.
+
+Key design decisions
+---------------------
+* Singleton model: the 2.3 GB model is loaded once per process on the first
+  call.  Subsequent calls are fast (~0.6 s per CV).
+* Lazy loading: the model is NOT imported at module level.  It is loaded on
+  the first call to GLiNERExtractor.extract() so the FastAPI startup is not
+  slowed down and a missing / OOM situation does not crash the server.
+* Graceful fallback: every failure path returns an empty dict so the caller
+  (cv_extractor.py) can fall through to the regex extractor.
+* ASCII apostrophes only -- never use curly/smart quotes in this file.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from typing import Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+_MODEL_NAME: str = os.getenv("GLINER_MODEL", "urchade/gliner_multi-v2.1")
+
+# Labels sent to GLiNER.  Adjust here if precision/recall balance shifts.
+_LABELS: List[str] = ["person name", "company", "school", "job title"]
+
+# Characters to strip from the ends of extracted spans.
+_STRIP_CHARS = " \t\n.,;:()[]\"'"
+
+# Patterns that indicate a span is NOT a person name.
+_EMAIL_LIKE_RE = re.compile(r"@|\.(?:com|fr|net|org|io|be|de|es|uk|ca|eu)\b", re.IGNORECASE)
+
+# Trailing date / location suffixes commonly attached to company spans.
+_COMPANY_SUFFIX_RE = re.compile(
+    r"\s*[\(\[\-]\s*(?:19|20)\d{2}.*$"
+    r"|\s+\-\s+[A-Z][A-Za-z\s]{0,30}$",
+    re.IGNORECASE,
+)
+
+_SECTION_HEADERS = frozenset({
+    "contact", "langues", "languages", "competences", "skills",
+    "experience", "experiences", "formation", "formations",
+    "education", "profil", "profile", "interets", "certifications",
+})
+
+
+class GLiNERExtractor:
+    """Singleton GLiNER extractor.  Instantiate once; reuse everywhere."""
+
+    _model = None
+    _load_attempted: bool = False
+    _available: bool = False
+
+    # ------------------------------------------------------------------
+    # Singleton / lazy-load
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def _load_model(cls) -> bool:
+        """Load the GLiNER model exactly once.  Thread-safe at Python GIL level."""
+        if cls._load_attempted:
+            return cls._available
+        cls._load_attempted = True
+        try:
+            from gliner import GLiNER  # type: ignore  # noqa: PLC0415
+            logger.info("Loading GLiNER model: %s ...", _MODEL_NAME)
+            cls._model = GLiNER.from_pretrained(_MODEL_NAME)
+            cls._available = True
+            logger.info("GLiNER model loaded successfully.")
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "GLiNER not available (%s: %s) -- falling back to regex extractor.",
+                type(exc).__name__,
+                exc,
+            )
+            cls._available = False
+        return cls._available
+
+    @property
+    def available(self) -> bool:
+        return self.__class__._available
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def extract(self, text: str) -> Dict:
+        """Extract CV entities from *text* using GLiNER.
+
+        Returns a dict with keys:
+            full_name   : str | None
+            companies   : List[str]
+            education   : List[str]
+            job_titles  : List[str]
+
+        Returns {} on failure so the caller can use the fallback extractor.
+        """
+        if not self._load_model():
+            return {}
+        if not text or not text.strip():
+            return {}
+
+        try:
+            # Truncate to ~6 000 chars (identity info is in the first half of the CV)
+            truncated = text[:6000]
+            raw_entities = self.__class__._model.predict_entities(
+                truncated,
+                _LABELS,
+                threshold=0.45,
+            )
+            return self._clean_entities(raw_entities)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("GLiNER extraction error: %s: %s", type(exc).__name__, exc)
+            return {}
+
+    # ------------------------------------------------------------------
+    # Internal cleaning
+    # ------------------------------------------------------------------
+
+    def _clean_entities(self, entities: List[Dict]) -> Dict:
+        """Group and clean the raw GLiNER entity spans."""
+        grouped: Dict[str, List[str]] = {
+            "person name": [],
+            "company": [],
+            "school": [],
+            "job title": [],
+        }
+        for ent in entities:
+            label = ent.get("label", "")
+            span = (ent.get("text") or "").strip(_STRIP_CHARS)
+            if label in grouped and span:
+                grouped[label].append(span)
+
+        full_name = self._best_person_name(grouped["person name"])
+        companies = self._clean_company_list(grouped["company"], grouped["school"])
+        education = self._dedup(grouped["school"])
+        job_titles = self._dedup(grouped["job title"])
+
+        return {
+            "full_name": full_name,
+            "companies": companies[:8],
+            "education": education[:6],
+            "job_titles": job_titles[:5],
+        }
+
+    # --- helpers ---------------------------------------------------------
+
+    def _best_person_name(self, candidates: List[str]) -> Optional[str]:
+        """Return the most plausible person name from GLiNER person-name spans."""
+        valid = []
+        for name in candidates:
+            name = name.strip(_STRIP_CHARS)
+            if not name:
+                continue
+            # Reject email-like strings
+            if _EMAIL_LIKE_RE.search(name):
+                continue
+            # Reject URL patterns
+            if "http" in name.lower() or "//" in name:
+                continue
+            # Reject section headers
+            if name.lower() in _SECTION_HEADERS:
+                continue
+            words = [w for w in name.split() if w]
+            # Must be between 1 and 5 words
+            if not 1 <= len(words) <= 5:
+                continue
+            # At least one word must start with a letter
+            if not any(w[0].isalpha() for w in words):
+                continue
+            valid.append(name)
+
+        if not valid:
+            return None
+        # Prefer the longest plausible name (more words = more specific)
+        valid.sort(key=lambda n: -len(n.split()))
+        return valid[0]
+
+    def _clean_company_list(
+        self, companies: List[str], schools: List[str]
+    ) -> List[str]:
+        """Clean and deduplicate companies; remove school overlaps."""
+        school_keys = {self._normalize_key(s) for s in schools}
+        seen = set()
+        result = []
+        for raw in companies:
+            # Strip trailing date/location suffixes
+            cleaned = _COMPANY_SUFFIX_RE.sub("", raw).strip(_STRIP_CHARS)
+            if not cleaned or len(cleaned) < 2:
+                continue
+            # Skip if it looks like a school
+            if self._normalize_key(cleaned) in school_keys:
+                continue
+            key = self._normalize_key(cleaned)
+            if key in seen:
+                continue
+            seen.add(key)
+            result.append(cleaned)
+        return result
+
+    def _dedup(self, items: List[str]) -> List[str]:
+        seen = set()
+        result = []
+        for item in items:
+            cleaned = item.strip(_STRIP_CHARS)
+            if not cleaned:
+                continue
+            key = self._normalize_key(cleaned)
+            if key in seen:
+                continue
+            seen.add(key)
+            result.append(cleaned)
+        return result
+
+    @staticmethod
+    def _normalize_key(text: str) -> str:
+        """Lowercase, strip accents (via ASCII encoding), collapse spaces."""
+        import unicodedata
+        nfkd = unicodedata.normalize("NFKD", text)
+        ascii_only = "".join(c for c in nfkd if not unicodedata.combining(c))
+        return re.sub(r"\s+", " ", ascii_only.lower().strip())
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton accessor
+# ---------------------------------------------------------------------------
+
+_instance: Optional[GLiNERExtractor] = None
+
+
+def get_gliner_extractor() -> GLiNERExtractor:
+    """Return the shared GLiNERExtractor instance (created once per process)."""
+    global _instance
+    if _instance is None:
+        _instance = GLiNERExtractor()
+    return _instance

--- a/backend/ai_module/nlp/resume_ner_extractor.py
+++ b/backend/ai_module/nlp/resume_ner_extractor.py
@@ -313,6 +313,12 @@ class ResumeNERExtractor:
             if any(char.isdigit() for char in line):
                 continue
 
+            # Skip lines whose content looks like a job title/role.
+            # "ingenieur" is a substring of "ingenieure" so this catches
+            # feminine / inflected forms without exhaustive enumeration.
+            if any(keyword in normalized for keyword in self.JOB_KEYWORDS):
+                continue
+
             words = [word for word in re.split(r'\s+', line) if word]
             # Require 2-4 words: real names have at least first + last name
             # (single-word aliases create too much noise from headers/bullets)
@@ -383,10 +389,15 @@ class ResumeNERExtractor:
         # Sort by score descending; on tie, prefer LONGER names (more complete)
         # Using -len so that longer strings sort first (ascending sort picks smallest first)
         candidates.sort(key=lambda item: (-item[0], -len(item[1])))
-        best_name = candidates[0][1]
+        best_score, best_name = candidates[0]
 
         # Always reject very short "names" regardless of email fallback
         if len(best_name) < 4:
+            return [email_fallback] if email_fallback else []
+
+        # Reject low-confidence candidates — they are likely noise (section headers
+        # or one-word fragments that slipped through) unless an email fallback exists.
+        if best_score < 3:
             return [email_fallback] if email_fallback else []
 
         return [best_name]

--- a/backend/app/services/cv_extractor.py
+++ b/backend/app/services/cv_extractor.py
@@ -56,6 +56,12 @@ try:
 except ImportError:
     NER_AVAILABLE = False
 
+try:
+    from ai_module.nlp.gliner_extractor import get_gliner_extractor as _get_gliner
+    GLINER_AVAILABLE = True
+except ImportError:
+    GLINER_AVAILABLE = False
+
 from ai_module.nlp.cv_cleaner import CVCleaner
 
 try:
@@ -105,6 +111,11 @@ class CVExtractionService:
         else:
             self.skill_extractor = _FallbackSkillExtractor()
         self.debug_enabled = os.getenv("CV_EXTRACTION_DEBUG", "0") == "1"
+        # Set USE_GLINER=false to disable GLiNER without redeploying code.
+        self._use_gliner = (
+            GLINER_AVAILABLE
+            and os.getenv("USE_GLINER", "true").strip().lower() not in ("false", "0", "no")
+        )
         self.hf_ner_model_name = os.getenv("HF_CV_NER_MODEL", "dslim/bert-base-NER")
         self.hf_parser = None
 
@@ -184,34 +195,40 @@ class CVExtractionService:
         )
     
     def _extract_structured_data(self, text: str) -> tuple:
-        """
-        Extract structured data via NER
-        
+        """Extract structured data via NER cascade: GLiNER -> regex -> BERT.
+
         Returns:
             Tuple of (structured_dict, quality_score)
         """
         if not self.ner_available or not text:
             return {}, 0
-        
+
         try:
             normalized_text = self._normalize_text_for_extraction(text)
-            hf_structured: Dict = {}
-            hf_quality = 0.0
-
-            # Run modern HF parser first (high precision on identity entities),
-            # then merge with the richer legacy extractor output.
-            if self.hf_parser is not None and self.hf_parser.available:
-                hf_structured, hf_quality = self.hf_parser.extract_structured_profile(normalized_text)
 
             if self.debug_enabled:
                 logger.info("TEXT EXTRACTED (preview): %s", normalized_text[:1000])
 
+            # --- Step 1: regex extractor (full breadth: skills, phone, email, …) ---
             structured = self.ner_extractor.extract_structured_profile(normalized_text)
             quality = self._compute_quality_score(structured)
 
+            # --- Step 2: GLiNER cascade (principal for name / companies / education) ---
+            # GLiNER overrides the regex results for high-precision identity fields.
+            # Falls back to regex values when GLiNER returns nothing for a field.
+            gliner_data = self._run_gliner(normalized_text)
+            if gliner_data:
+                structured = self._apply_gliner_override(structured, gliner_data)
+
+            # --- Step 3: BERT NER enrichment (fills gaps not covered by regex+GLiNER) ---
+            hf_structured: Dict = {}
+            hf_quality = 0.0
+            if self.hf_parser is not None and self.hf_parser.available:
+                hf_structured, hf_quality = self.hf_parser.extract_structured_profile(normalized_text)
             if hf_structured:
                 structured = self._merge_structured_profiles(base=structured, hf=hf_structured)
 
+            # --- Step 4: postprocess & score ---
             structured = self._postprocess_structured(structured)
             quality = max(quality, hf_quality, self._compute_quality_score(structured))
 
@@ -224,13 +241,61 @@ class CVExtractionService:
                     "companies": len(structured.get("companies", [])),
                     "education": len(structured.get("education", [])),
                     "skills": len(structured.get("skills", [])),
+                    "gliner_used": bool(gliner_data),
                 }
                 logger.info("ENTITIES SUMMARY: %s", entity_counts)
 
             return structured, quality
         except Exception as e:
-            print(f"⚠️ Structured extraction failed: {e}")
+            print(f"Warning: Structured extraction failed: {e}")
             return {}, 0
+
+    def _run_gliner(self, text: str) -> Dict:
+        """Run GLiNER and return its dict, or {} on any failure / disabled."""
+        if not self._use_gliner:
+            return {}
+        try:
+            extractor = _get_gliner()
+            # Trigger lazy model load on first call
+            extractor._load_model()
+            if not extractor.available:
+                return {}
+            return extractor.extract(text)
+        except Exception as exc:
+            logger.warning("GLiNER run error: %s", exc)
+            return {}
+
+    def _apply_gliner_override(self, structured: Dict, gliner: Dict) -> Dict:
+        """Override regex-extracted identity fields with GLiNER results.
+
+        GLiNER is higher precision for name / companies / education / job_titles.
+        Regex is kept for everything else (skills, phone, email, languages, etc.).
+        A GLiNER field only overrides when GLiNER actually found something
+        (non-empty), so the regex value is kept as fallback when GLiNER is silent.
+        """
+        result = dict(structured)
+
+        if gliner.get("full_name"):
+            result["full_name"] = gliner["full_name"]
+            result["name"] = gliner["full_name"]
+
+        if gliner.get("companies"):
+            result["companies"] = gliner["companies"]
+
+        if gliner.get("education"):
+            result["education"] = gliner["education"]
+
+        if gliner.get("job_titles"):
+            result["job_titles"] = gliner["job_titles"]
+
+        # Tag the extraction metadata so we know GLiNER ran
+        meta = result.get("extraction_metadata")
+        if not isinstance(meta, dict):
+            meta = {}
+        meta["gliner_model"] = os.getenv("GLINER_MODEL", "urchade/gliner_multi-v2.1")
+        result["extraction_metadata"] = meta
+
+        return result
 
     def _merge_structured_profiles(self, base: Dict, hf: Dict) -> Dict:
         """Merge legacy and HF structured outputs while preserving richer fields."""

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -36,3 +36,5 @@ beautifulsoup4>=4.12.0
 lxml>=4.9.0
 # FAISS for similarity search
 faiss-cpu>=1.7.4
+# GLiNER — zero-shot NER principal extractor for CV identity fields
+gliner>=0.2.0

--- a/backend/scripts/test_gliner_extraction.py
+++ b/backend/scripts/test_gliner_extraction.py
@@ -1,0 +1,242 @@
+"""Regression test for GLiNER-based CV extraction.
+
+Verifies that on the 2-column CV fixture (Raphael MARTIN):
+  - full_name is extracted correctly even when the name appears deep in the
+    reflowed text (the position-scoring weakness of the regex extractor).
+  - DIOR / ORANGE / DANONE are extracted as companies.
+
+Also checks that the 1-column CV (Sophie BERNARD) does not regress.
+
+Finally, verifies that USE_GLINER=false falls back to the regex extractor
+without crashing.
+
+Run:
+    cd backend
+    python scripts/test_gliner_extraction.py
+
+Exit code 0 = all checks passed, 1 = at least one failure.
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+BACKEND = os.path.abspath(os.path.join(HERE, ".."))
+if BACKEND not in sys.path:
+    sys.path.insert(0, BACKEND)
+
+# Regenerate fixtures on demand
+spec = importlib.util.spec_from_file_location(
+    "_make_test_cvs", os.path.join(HERE, "_make_test_cvs.py")
+)
+_mk = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(_mk)
+
+FIXTURES = os.path.join(BACKEND, "tests", "fixtures")
+TWO_COL = os.path.join(FIXTURES, "cv_two_column.pdf")
+ONE_COL = os.path.join(FIXTURES, "cv_one_column.pdf")
+
+_failures: list[str] = []
+
+
+def check(cond: bool, msg: str) -> None:
+    status = "PASS" if cond else "FAIL"
+    print(f"  [{status}] {msg}")
+    if not cond:
+        _failures.append(msg)
+
+
+# ---------------------------------------------------------------------------
+# Check GLiNER availability before running model-dependent tests
+# ---------------------------------------------------------------------------
+
+def _gliner_importable() -> bool:
+    try:
+        import gliner  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
+
+GLINER_PRESENT = _gliner_importable()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _name_matches(extracted: str | None, first: str, last: str) -> bool:
+    """Case-insensitive check that both first and last name tokens appear."""
+    if not extracted:
+        return False
+    lower = extracted.lower()
+    return first.lower() in lower and last.lower() in lower
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_gliner_unit():
+    """Unit test: GLiNERExtractor on raw CV text (no PDF parsing)."""
+    print("\n=== GLiNER unit test (raw text) ===")
+    if not GLINER_PRESENT:
+        print("  [SKIP] gliner package not installed -- skipping unit test")
+        return
+
+    from ai_module.nlp.gliner_extractor import GLiNERExtractor
+
+    extractor = GLiNERExtractor()
+    if not extractor._load_model():
+        print("  [SKIP] GLiNER model could not be loaded (network / RAM) -- skipping")
+        return
+
+    sample_text = """Raphael MARTIN
+Commercial Senior
+
+EXPERIENCES
+Responsable Commercial - DIOR (2020-2024)
+Charge d affaires - ORANGE (2016-2020)
+Commercial - DANONE (2014-2016)
+
+FORMATION
+Master Commerce - Universite Sorbonne (2014)
+Licence Gestion - ESUP (2012)
+"""
+    result = extractor.extract(sample_text)
+    print(f"  GLiNER raw output: {result}")
+
+    check(
+        _name_matches(result.get("full_name"), "Raphael", "MARTIN"),
+        f"GLiNER unit: full_name contains 'Raphael MARTIN' (got {result.get('full_name')!r})",
+    )
+    for co in ("DIOR", "ORANGE", "DANONE"):
+        companies_lower = [c.upper() for c in result.get("companies", [])]
+        check(
+            any(co in c for c in companies_lower),
+            f"GLiNER unit: company '{co}' extracted (companies={result.get('companies')})",
+        )
+
+
+def test_pipeline_two_column():
+    """Integration: full pipeline on cv_two_column.pdf."""
+    print("\n=== Pipeline integration — 2-column CV (Raphael MARTIN) ===")
+
+    # Force-enable GLiNER for this test (it may be disabled via env)
+    os.environ["USE_GLINER"] = "true"
+
+    # Re-import to pick up the env var (singleton may already be created,
+    # but _use_gliner is set per-instance so we create a fresh one)
+    from app.services.cv_extractor import CVExtractionService, extract_text_from_pdf
+
+    # Check text extraction first (column reflow)
+    text = extract_text_from_pdf(TWO_COL)
+    check("Raphael MARTIN" in text, "text extraction: 'Raphael MARTIN' in reflowed text")
+
+    if not GLINER_PRESENT:
+        print("  [SKIP] gliner not installed -- pipeline GLiNER checks skipped")
+        print("  Running regex-only pipeline check ...")
+        svc = CVExtractionService()
+        result = svc.extract_from_text(text)
+        candidate = svc.to_candidate_dict(result)
+        name = candidate.get("full_name") or candidate.get("extracted_name")
+        print(f"  Regex-only full_name: {name!r}")
+        print(f"  Regex-only companies: {candidate.get('extracted_companies')!r}")
+        return
+
+    svc = CVExtractionService()
+    result = svc.extract_from_text(text)
+    candidate = svc.to_candidate_dict(result)
+
+    name = candidate.get("full_name") or candidate.get("extracted_name")
+    print(f"  Extracted full_name: {name!r}")
+    check(
+        _name_matches(name, "Raphael", "Martin"),
+        f"pipeline 2-col: full_name ~ 'Raphael MARTIN' (got {name!r})",
+    )
+
+    import json
+    companies_raw = candidate.get("extracted_companies") or "[]"
+    if isinstance(companies_raw, list):
+        companies = companies_raw
+    else:
+        try:
+            companies = json.loads(companies_raw)
+        except Exception:
+            companies = []
+    companies_str = " ".join(str(c).upper() for c in companies)
+    print(f"  Extracted companies: {companies}")
+    for co in ("DIOR", "ORANGE", "DANONE"):
+        check(co in companies_str, f"pipeline 2-col: company '{co}' in extracted_companies")
+
+
+def test_pipeline_one_column():
+    """Regression: 1-column CV must still work correctly."""
+    print("\n=== Pipeline integration — 1-column CV (Sophie BERNARD) — regression ===")
+
+    from app.services.cv_extractor import CVExtractionService, extract_text_from_pdf
+
+    text = extract_text_from_pdf(ONE_COL)
+    check("Sophie BERNARD" in text, "text extraction: 'Sophie BERNARD' in text")
+
+    svc = CVExtractionService()
+    result = svc.extract_from_text(text)
+    candidate = svc.to_candidate_dict(result)
+
+    name = candidate.get("full_name") or candidate.get("extracted_name")
+    print(f"  Extracted full_name: {name!r}")
+    check(
+        _name_matches(name, "Sophie", "Bernard"),
+        f"pipeline 1-col: full_name ~ 'Sophie BERNARD' (got {name!r})",
+    )
+
+
+def test_fallback_without_gliner():
+    """Verify USE_GLINER=false falls back to regex without crashing."""
+    print("\n=== Fallback: USE_GLINER=false ===")
+
+    os.environ["USE_GLINER"] = "false"
+
+    # Must import AFTER setting the env var so a fresh instance picks it up
+    from app.services.cv_extractor import CVExtractionService
+
+    svc = CVExtractionService()
+    check(not svc._use_gliner, "USE_GLINER=false: _use_gliner is False on service instance")
+
+    sample = "Jean DUPONT\nIngenieur Logiciel\njean.dupont@example.com"
+    try:
+        result = svc.extract_from_text(sample)
+        candidate = svc.to_candidate_dict(result)
+        check(True, "USE_GLINER=false: extract_from_text does not crash")
+    except Exception as exc:
+        check(False, f"USE_GLINER=false: extract_from_text crashed ({exc})")
+
+    # Restore
+    os.environ["USE_GLINER"] = "true"
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    if not os.path.exists(TWO_COL) or not os.path.exists(ONE_COL):
+        print("Generating test fixtures ...")
+        _mk.make_two_column_cv(TWO_COL)
+        _mk.make_one_column_cv(ONE_COL)
+
+    test_gliner_unit()
+    test_pipeline_two_column()
+    test_pipeline_one_column()
+    test_fallback_without_gliner()
+
+    print()
+    if _failures:
+        print(f"RESULT: {len(_failures)} check(s) FAILED")
+        for f in _failures:
+            print("  - " + f)
+        sys.exit(1)
+    print("RESULT: all checks passed")
+    sys.exit(0)


### PR DESCRIPTION
…lback

- Add backend/ai_module/nlp/gliner_extractor.py: singleton GLiNERExtractor (urchade/gliner_multi-v2.1, lazy-loaded, USE_GLINER env var, graceful fallback)
- Wire GLiNER cascade into CVExtractionService._extract_structured_data: regex -> GLiNER override -> BERT enrichment -> postprocess
- Fix _extract_names: add JOB_KEYWORDS filter so role lines ("Ingenieure Logiciel") are never scored as person names; add score<3 fallback guard
- Add gliner>=0.2.0 to requirements.txt
- Add backend/scripts/test_gliner_extraction.py with unit + pipeline tests