### PR TITLE
fix: clean GLiNER output — filter artifacts, redirect schools, saniti…

### DIFF
--- a/backend/ai_module/nlp/gliner_extractor.py
+++ b/backend/ai_module/nlp/gliner_extractor.py
@@ -1,7 +1,7 @@
 """GLiNER-based CV entity extractor.
 
 Uses urchade/gliner_multi-v2.1 as the principal NER layer for high-precision
-extraction of person names, companies, schools and job titles.
+extraction of person names, companies, schools, job titles and interests.
 
 Key design decisions
 ---------------------
@@ -13,6 +13,14 @@ Key design decisions
 * Graceful fallback: every failure path returns an empty dict so the caller
   (cv_extractor.py) can fall through to the regex extractor.
 * ASCII apostrophes only -- never use curly/smart quotes in this file.
+
+Post-processing guarantees
+---------------------------
+* BERT tokenizer artifacts (spans starting with '##') are discarded.
+* Spans with fewer than 3 alphabetic characters are discarded (noise).
+* Single non-acronym words of 3 or fewer total characters are discarded.
+* Company spans that match school/university keywords are moved to education.
+* Interests that match the candidate name or a CV section header are removed.
 """
 
 from __future__ import annotations
@@ -26,14 +34,22 @@ logger = logging.getLogger(__name__)
 
 _MODEL_NAME: str = os.getenv("GLINER_MODEL", "urchade/gliner_multi-v2.1")
 
-# Labels sent to GLiNER.  Adjust here if precision/recall balance shifts.
-_LABELS: List[str] = ["person name", "company", "school", "job title"]
+# Labels sent to GLiNER.  Zero-shot model supports any labels.
+_LABELS: List[str] = [
+    "person name",
+    "company",
+    "school",
+    "job title",
+    "interest",
+]
 
 # Characters to strip from the ends of extracted spans.
 _STRIP_CHARS = " \t\n.,;:()[]\"'"
 
 # Patterns that indicate a span is NOT a person name.
-_EMAIL_LIKE_RE = re.compile(r"@|\.(?:com|fr|net|org|io|be|de|es|uk|ca|eu)\b", re.IGNORECASE)
+_EMAIL_LIKE_RE = re.compile(
+    r"@|\.(?:com|fr|net|org|io|be|de|es|uk|ca|eu)\b", re.IGNORECASE
+)
 
 # Trailing date / location suffixes commonly attached to company spans.
 _COMPANY_SUFFIX_RE = re.compile(
@@ -42,12 +58,77 @@ _COMPANY_SUFFIX_RE = re.compile(
     re.IGNORECASE,
 )
 
-_SECTION_HEADERS = frozenset({
-    "contact", "langues", "languages", "competences", "skills",
-    "experience", "experiences", "formation", "formations",
-    "education", "profil", "profile", "interets", "certifications",
+# Normalized CV section header names.
+# Used to reject section titles that leak into entity lists.
+# All values must be in their _normalize_key() form (lowercase, no accents,
+# no extra spaces) so comparisons are accent-agnostic.
+_SECTION_HEADERS: frozenset = frozenset({
+    "contact",
+    "langues", "languages",
+    "competences", "competence", "skills",
+    "experience", "experiences",
+    "formation", "formations",
+    "education",
+    "profil", "profile",
+    "interets", "interet",
+    "centres d interet", "centres d interets",
+    "certifications", "certification",
+    "loisirs", "activites", "activite",
+    "intitule", "intitule du poste", "intitule du stage",
+    "objectif", "objectifs",
+    "references", "recommandations",
+    "publications",
+    "projets", "projet", "realisations",
+    "informations", "informations personnelles",
+    "qualites", "atouts", "valeurs",
+    "stage", "stages", "alternance",
 })
 
+# Normalized keywords that identify school / university entries.
+# Checked as WORD tokens (not substrings) against the normalized span to
+# avoid false positives (e.g. a company name that happens to contain 'school').
+_SCHOOL_KEYWORDS: frozenset = frozenset({
+    "universite",
+    "ecole", "ecoles",
+    "institut", "institute",
+    "school",
+    "faculte", "facultes",
+    "iut", "bts", "esup",
+    "lycee", "lycees",
+    "college",
+    "academy", "academie",
+    "insa", "supinfo", "epitech",
+})
+
+
+# ---------------------------------------------------------------------------
+# Module-level span-level filters (no class state needed)
+# ---------------------------------------------------------------------------
+
+def _is_noise_span(span: str) -> bool:
+    """Return True if *span* is an artifact or too-short fragment to keep.
+
+    Filtered cases:
+    - BERT wordpiece tokenizer artifacts: prefix '##' (e.g. '##cence Pro ...')
+    - Fewer than 3 alphabetic characters (e.g. 'Li' = 2 alpha)
+    - Single non-acronym word of 3 or fewer total chars (e.g. 'Esp')
+      All-uppercase 2-3 char words are valid acronyms (IBM, SAP) and pass.
+    """
+    if span.startswith("##"):
+        return True
+    alpha_count = sum(1 for c in span if c.isalpha())
+    if alpha_count < 3:
+        return True
+    # Single short word: keep only if it is a pure uppercase acronym
+    words = span.split()
+    if len(words) == 1 and len(span) <= 3 and not span.isupper():
+        return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Main class
+# ---------------------------------------------------------------------------
 
 class GLiNERExtractor:
     """Singleton GLiNER extractor.  Instantiate once; reuse everywhere."""
@@ -57,7 +138,7 @@ class GLiNERExtractor:
     _available: bool = False
 
     # ------------------------------------------------------------------
-    # Singleton / lazy-load
+    # Singleton / lazy-load (do not touch this block per project rules)
     # ------------------------------------------------------------------
 
     @classmethod
@@ -93,12 +174,14 @@ class GLiNERExtractor:
         """Extract CV entities from *text* using GLiNER.
 
         Returns a dict with keys:
-            full_name   : str | None
-            companies   : List[str]
-            education   : List[str]
-            job_titles  : List[str]
+            full_name  : str | None
+            companies  : List[str]
+            education  : List[str]
+            job_titles : List[str]
+            interests  : List[str]
 
-        Returns {} on failure so the caller can use the fallback extractor.
+        Returns {} on failure so the caller can fall through to the regex
+        extractor.
         """
         if not self._load_model():
             return {}
@@ -106,7 +189,8 @@ class GLiNERExtractor:
             return {}
 
         try:
-            # Truncate to ~6 000 chars (identity info is in the first half of the CV)
+            # Truncate to ~6 000 chars (identity info is in the first half of
+            # the CV; processing the full text risks OOM on long documents).
             truncated = text[:6000]
             raw_entities = self.__class__._model.predict_entities(
                 truncated,
@@ -115,37 +199,69 @@ class GLiNERExtractor:
             )
             return self._clean_entities(raw_entities)
         except Exception as exc:  # noqa: BLE001
-            logger.warning("GLiNER extraction error: %s: %s", type(exc).__name__, exc)
+            logger.warning(
+                "GLiNER extraction error: %s: %s", type(exc).__name__, exc
+            )
             return {}
 
     # ------------------------------------------------------------------
-    # Internal cleaning
+    # Post-processing / cleaning  (the only section touched by this fix)
     # ------------------------------------------------------------------
 
     def _clean_entities(self, entities: List[Dict]) -> Dict:
-        """Group and clean the raw GLiNER entity spans."""
+        """Group, filter and clean the raw GLiNER entity spans.
+
+        Pipeline:
+        1. Discard noise spans (## artifacts, < 3 alpha chars, short non-acronyms).
+        2. Detect company spans that look like schools and redirect them to the
+           education pool.
+        3. Deduplicate and cap each list.
+        4. Filter interests: remove the candidate name and CV section headers.
+        """
         grouped: Dict[str, List[str]] = {
             "person name": [],
             "company": [],
             "school": [],
             "job title": [],
+            "interest": [],
         }
+
+        # --- Step 1: group spans, discarding noise immediately ---------------
         for ent in entities:
             label = ent.get("label", "")
-            span = (ent.get("text") or "").strip(_STRIP_CHARS)
-            if label in grouped and span:
-                grouped[label].append(span)
+            raw = (ent.get("text") or "").strip(_STRIP_CHARS)
+            if label not in grouped or not raw:
+                continue
+            if _is_noise_span(raw):
+                logger.debug("GLiNER noise filtered: %r (%s)", raw, label)
+                continue
+            grouped[label].append(raw)
 
+        # --- Step 2: separate school-like entries from company list ----------
+        extra_schools: List[str] = []
+        real_companies: List[str] = []
+        for span in grouped["company"]:
+            if self._is_school_like(span):
+                extra_schools.append(span)
+            else:
+                real_companies.append(span)
+
+        # Combined school pool: GLiNER-labeled schools + redirected companies
+        all_schools = grouped["school"] + extra_schools
+
+        # --- Step 3: build clean field lists ---------------------------------
         full_name = self._best_person_name(grouped["person name"])
-        companies = self._clean_company_list(grouped["company"], grouped["school"])
-        education = self._dedup(grouped["school"])
+        companies = self._clean_company_list(real_companies, all_schools)
+        education = self._dedup(all_schools)
         job_titles = self._dedup(grouped["job title"])
+        interests = self._clean_interests(grouped["interest"], full_name)
 
         return {
             "full_name": full_name,
             "companies": companies[:8],
             "education": education[:6],
             "job_titles": job_titles[:5],
+            "interests": interests[:8],
         }
 
     # --- helpers ---------------------------------------------------------
@@ -157,55 +273,89 @@ class GLiNERExtractor:
             name = name.strip(_STRIP_CHARS)
             if not name:
                 continue
-            # Reject email-like strings
             if _EMAIL_LIKE_RE.search(name):
                 continue
-            # Reject URL patterns
             if "http" in name.lower() or "//" in name:
                 continue
-            # Reject section headers
-            if name.lower() in _SECTION_HEADERS:
+            norm = self._normalize_key(name)
+            if norm in _SECTION_HEADERS:
                 continue
             words = [w for w in name.split() if w]
-            # Must be between 1 and 5 words
             if not 1 <= len(words) <= 5:
                 continue
-            # At least one word must start with a letter
             if not any(w[0].isalpha() for w in words):
                 continue
             valid.append(name)
 
         if not valid:
             return None
-        # Prefer the longest plausible name (more words = more specific)
+        # Prefer multi-word names (more complete) over single tokens.
         valid.sort(key=lambda n: -len(n.split()))
         return valid[0]
 
     def _clean_company_list(
         self, companies: List[str], schools: List[str]
     ) -> List[str]:
-        """Clean and deduplicate companies; remove school overlaps."""
+        """Clean and deduplicate companies.
+
+        A company span is rejected when:
+        - It still looks like a school (cross-check after redirect pass).
+        - Its normalized key duplicates an already-kept entry.
+        """
         school_keys = {self._normalize_key(s) for s in schools}
-        seen = set()
-        result = []
+        seen: set = set()
+        result: List[str] = []
         for raw in companies:
-            # Strip trailing date/location suffixes
             cleaned = _COMPANY_SUFFIX_RE.sub("", raw).strip(_STRIP_CHARS)
-            if not cleaned or len(cleaned) < 2:
+            if not cleaned:
                 continue
-            # Skip if it looks like a school
-            if self._normalize_key(cleaned) in school_keys:
+            if self._is_school_like(cleaned):
                 continue
             key = self._normalize_key(cleaned)
-            if key in seen:
+            if key in school_keys or key in seen:
                 continue
             seen.add(key)
             result.append(cleaned)
         return result
 
+    def _clean_interests(
+        self, interests: List[str], full_name: Optional[str]
+    ) -> List[str]:
+        """Filter interests: reject the candidate name, section headers, and
+        form-label patterns (strings containing '/' or '|').
+        """
+        name_key = self._normalize_key(full_name) if full_name else None
+        seen: set = set()
+        result: List[str] = []
+        for raw in interests:
+            span = raw.strip(_STRIP_CHARS)
+            if not span:
+                continue
+            # Reject form labels (e.g. 'INTITULE DU POSTE / STAGE')
+            if "/" in span or "|" in span:
+                continue
+            key = self._normalize_key(span)
+            # Reject if it matches the candidate name
+            if name_key and key == name_key:
+                continue
+            # Reject exact section header matches
+            if key in _SECTION_HEADERS:
+                continue
+            # Reject if any word token is an unambiguous section header
+            tokens = set(re.split(r"\W+", key))
+            tokens.discard("")
+            if tokens & _SECTION_HEADERS:
+                continue
+            if key in seen:
+                continue
+            seen.add(key)
+            result.append(span)
+        return result
+
     def _dedup(self, items: List[str]) -> List[str]:
-        seen = set()
-        result = []
+        """Deduplicate a list of spans preserving first-seen order."""
+        seen: set = set()
+        result: List[str] = []
         for item in items:
             cleaned = item.strip(_STRIP_CHARS)
             if not cleaned:
@@ -218,8 +368,21 @@ class GLiNERExtractor:
         return result
 
     @staticmethod
+    def _is_school_like(span: str) -> bool:
+        """Return True if *span* looks like a school / university entry.
+
+        Detection: check whether any word token in the normalized span matches
+        a known education keyword.  Word-based (not substring) to avoid false
+        positives from company names that contain those letters incidentally.
+        """
+        norm = GLiNERExtractor._normalize_key(span)
+        tokens = set(re.split(r"\W+", norm))
+        tokens.discard("")
+        return bool(tokens & _SCHOOL_KEYWORDS)
+
+    @staticmethod
     def _normalize_key(text: str) -> str:
-        """Lowercase, strip accents (via ASCII encoding), collapse spaces."""
+        """Lowercase and accent-strip *text*, collapse internal whitespace."""
         import unicodedata
         nfkd = unicodedata.normalize("NFKD", text)
         ascii_only = "".join(c for c in nfkd if not unicodedata.combining(c))

--- a/backend/scripts/test_gliner_extraction.py
+++ b/backend/scripts/test_gliner_extraction.py
@@ -10,6 +10,10 @@ Also checks that the 1-column CV (Sophie BERNARD) does not regress.
 Finally, verifies that USE_GLINER=false falls back to the regex extractor
 without crashing.
 
+test_cleanup_logic() is a pure unit test for the GLiNER post-processing
+pipeline.  It uses synthetic (mock) entity output so it runs without the
+GLiNER package being installed.
+
 Run:
     cd backend
     python scripts/test_gliner_extraction.py
@@ -78,6 +82,117 @@ def _name_matches(extracted: str | None, first: str, last: str) -> bool:
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
+
+def test_cleanup_logic():
+    """Post-processing unit test: uses synthetic (mock) GLiNER output.
+
+    Does NOT require the GLiNER package to be installed -- it calls
+    _clean_entities() directly.  Validates:
+      - '##' BERT artifacts are removed
+      - fragments with < 3 alpha chars ('Li') and short non-acronyms ('Esp')
+        are removed
+      - school-like company spans (ESUP, Universite Sorbonne) are moved to
+        education, not kept in companies
+      - interests do not contain the candidate name or a section header
+    """
+    print("\n=== GLiNER cleanup unit test (no model needed) ===")
+
+    from ai_module.nlp.gliner_extractor import GLiNERExtractor
+
+    extractor = GLiNERExtractor()
+
+    # Simulate raw GLiNER output that mirrors the observed 2-column CV problem.
+    # ASCII apostrophes and no accented literals (to keep this file ASCII-safe).
+    mock_entities = [
+        # --- person name ---
+        {"label": "person name", "text": "Raphael MARTIN"},
+
+        # --- companies: 3 real + 4 pollutants ---
+        {"label": "company", "text": "DIOR"},
+        {"label": "company", "text": "ORANGE"},
+        {"label": "company", "text": "DANONE"},
+        {"label": "company", "text": "ESUP"},                 # school, not company
+        {"label": "company", "text": "Universite Sorbonne"},  # school, not company
+        {"label": "company", "text": "Esp"},                  # short non-acronym fragment
+        {"label": "company", "text": "Li"},                   # < 3 alpha chars
+        {
+            "label": "company",
+            "text": "##cence Pro Commerce et Distribution E",  # BERT ## artifact
+        },
+
+        # --- schools (GLiNER-labeled) ---
+        {"label": "school", "text": "Universite Sorbonne"},
+        {"label": "school", "text": "ESUP"},
+
+        # --- interests: 1 valid + 2 pollutants ---
+        {"label": "interest", "text": "Raphael MARTIN"},         # candidate name
+        {"label": "interest", "text": "INTITULE DU POSTE / STAGE"},  # form label with /
+        {"label": "interest", "text": "Voyage"},                 # valid interest
+    ]
+
+    result = extractor._clean_entities(mock_entities)
+    print(f"  full_name  : {result.get('full_name')!r}")
+    print(f"  companies  : {result.get('companies')}")
+    print(f"  education  : {result.get('education')}")
+    print(f"  job_titles : {result.get('job_titles')}")
+    print(f"  interests  : {result.get('interests')}")
+
+    companies = result.get("companies", [])
+    education = result.get("education", [])
+    interests = result.get("interests", [])
+    full_name = result.get("full_name")
+
+    # full_name must not regress
+    check(
+        _name_matches(full_name, "Raphael", "Martin"),
+        f"cleanup: full_name is Raphael MARTIN (got {full_name!r})",
+    )
+
+    # --- companies ---
+    for co in ("DIOR", "ORANGE", "DANONE"):
+        check(co in companies, f"cleanup: '{co}' kept in companies (got {companies})")
+
+    check(
+        "ESUP" not in companies,
+        f"cleanup: 'ESUP' NOT in companies (got {companies})",
+    )
+    check(
+        not any("Sorbonne" in c or "sorbonne" in c.lower() for c in companies),
+        f"cleanup: 'Universite Sorbonne' NOT in companies (got {companies})",
+    )
+    check(
+        not any(c.startswith("##") for c in companies),
+        f"cleanup: no '##' artifacts in companies (got {companies})",
+    )
+    check(
+        not any(c in ("Esp", "Li") for c in companies),
+        f"cleanup: short fragments not in companies (got {companies})",
+    )
+
+    # --- education ---
+    check(
+        any("Sorbonne" in e or "sorbonne" in e.lower() for e in education),
+        f"cleanup: 'Universite Sorbonne' in education (got {education})",
+    )
+    check(
+        any("ESUP" in e or "esup" in e.lower() for e in education),
+        f"cleanup: 'ESUP' in education (got {education})",
+    )
+
+    # --- interests ---
+    check(
+        "Voyage" in interests,
+        f"cleanup: valid interest 'Voyage' kept (got {interests})",
+    )
+    check(
+        not any((full_name or "").lower() == i.lower() for i in interests),
+        f"cleanup: candidate name NOT in interests (got {interests})",
+    )
+    check(
+        not any("INTITULE" in i.upper() or "/" in i for i in interests),
+        f"cleanup: form label NOT in interests (got {interests})",
+    )
+
 
 def test_gliner_unit():
     """Unit test: GLiNERExtractor on raw CV text (no PDF parsing)."""
@@ -227,6 +342,7 @@ if __name__ == "__main__":
         _mk.make_two_column_cv(TWO_COL)
         _mk.make_one_column_cv(ONE_COL)
 
+    test_cleanup_logic()
     test_gliner_unit()
     test_pipeline_two_column()
     test_pipeline_one_column()


### PR DESCRIPTION
…ze interests

- Discard BERT ## tokenizer artifacts (e.g. '##cence Pro Commerce...')
- Discard spans with < 3 alphabetic chars ('Li') or short non-acronyms ('Esp')
- Detect school-like company spans ('ESUP', 'Universite Sorbonne') via word- token intersection with _SCHOOL_KEYWORDS and move them to education pool
- Add interests post-processing: reject candidate name, form labels with '/', and CV section headers (exact + word-token match against _SECTION_HEADERS)
- Expand _SECTION_HEADERS and add _SCHOOL_KEYWORDS module-level constants
- Add 'interest' to _LABELS so GLiNER extracts this field
- Add test_cleanup_logic() using mock entities (no GLiNER install required)