### PR TITLE
feat(frontend): premium UI redesign across public site + app

### DIFF
--- a/frontend/src/app/admin-login/page.tsx
+++ b/frontend/src/app/admin-login/page.tsx
@@ -43,15 +43,23 @@ export default function AdminLoginPage() {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-950 px-4">
-      <div className="w-full max-w-sm space-y-6">
+    <div className="relative min-h-screen flex items-center justify-center overflow-hidden bg-slate-950 px-4">
+      {/* Glow background */}
+      <div className="pointer-events-none absolute inset-0">
+        <div className="absolute left-1/2 top-0 h-72 w-72 -translate-x-1/2 rounded-full bg-indigo-600/20 blur-3xl" />
+        <div className="absolute bottom-0 right-1/4 h-72 w-72 rounded-full bg-rose-600/15 blur-3xl" />
+      </div>
+
+      <div className="relative w-full max-w-sm space-y-6">
         <div className="text-center">
-          <div className="text-4xl mb-3">🔐</div>
-          <h1 className="text-2xl font-bold text-white">Espace Administrateur</h1>
-          <p className="text-gray-400 text-sm mt-1">Connexion reservee aux admins</p>
+          <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-2xl bg-gradient-to-br from-indigo-600 to-violet-600 text-white shadow-lg shadow-indigo-900/50">
+            <span className="text-2xl">🔐</span>
+          </div>
+          <h1 className="font-display text-2xl font-extrabold text-white">Espace Administrateur</h1>
+          <p className="mt-1 text-sm text-slate-400">Connexion réservée aux admins</p>
         </div>
 
-        <form onSubmit={handleSubmit} className="bg-gray-900 rounded-xl p-8 space-y-5 shadow-2xl border border-gray-800">
+        <form onSubmit={handleSubmit} className="space-y-5 rounded-2xl border border-white/10 bg-white/[0.04] p-8 shadow-2xl backdrop-blur-xl">
           <div>
             <label htmlFor="admin-email" className="block text-sm font-medium text-gray-300 mb-1">
               Email
@@ -93,7 +101,7 @@ export default function AdminLoginPage() {
           <button
             type="submit"
             disabled={loading}
-            className="w-full py-3 rounded-lg bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed text-white font-semibold transition-colors"
+            className="btn-primary w-full disabled:cursor-not-allowed disabled:opacity-50"
           >
             {loading ? "Connexion..." : "Se connecter"}
           </button>

--- a/frontend/src/app/admin/dashboard/page.tsx
+++ b/frontend/src/app/admin/dashboard/page.tsx
@@ -68,11 +68,16 @@ export default function AdminDashboard() {
     <Layout>
       <div className="max-w-5xl mx-auto">
         {/* Header */}
-        <div className="flex items-center gap-3 mb-8">
-          <ShieldAlert className="h-7 w-7 text-red-600" />
-          <div>
-            <h1 className="text-2xl font-bold text-gray-900">Tableau de bord Admin</h1>
-            <p className="text-sm text-gray-500">Vue globale de la plateforme</p>
+        <div className="relative mb-8 overflow-hidden rounded-3xl bg-gradient-to-br from-slate-900 via-indigo-950 to-slate-900 p-7 text-white shadow-xl">
+          <div className="absolute -right-6 -top-8 h-36 w-36 rounded-full bg-indigo-500/30 blur-2xl" />
+          <div className="relative flex items-center gap-3">
+            <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-red-500/20 text-red-300 ring-1 ring-red-400/30">
+              <ShieldAlert className="h-6 w-6" />
+            </div>
+            <div>
+              <h1 className="font-display text-2xl font-extrabold sm:text-3xl">Tableau de bord Admin</h1>
+              <p className="text-sm text-slate-300">Vue globale de la plateforme</p>
+            </div>
           </div>
         </div>
 
@@ -111,14 +116,12 @@ export default function AdminDashboard() {
           <div className="grid grid-cols-2 lg:grid-cols-4 gap-5">
             {cards.map(({ label, value, icon: Icon, color, border, href }) => {
               const card = (
-                <div
-                  className={`rounded-xl bg-white p-6 shadow-sm ${border} ${href ? 'hover:shadow-md transition-shadow cursor-pointer' : ''}`}
-                >
-                  <div className={`inline-flex rounded-lg p-2 ${color} mb-3`}>
+                <div className={`card-premium ${href ? 'card-glow cursor-pointer' : ''} p-6 ${border}`}>
+                  <div className={`mb-3 inline-flex rounded-xl p-2.5 ${color}`}>
                     <Icon className="h-5 w-5" />
                   </div>
-                  <p className="text-3xl font-bold text-gray-900">{value.toLocaleString()}</p>
-                  <p className="text-sm text-gray-500 mt-1">{label}</p>
+                  <p className="font-display text-3xl font-extrabold text-gray-900">{value.toLocaleString()}</p>
+                  <p className="mt-1 text-sm text-gray-500">{label}</p>
                 </div>
               );
               return href ? (

--- a/frontend/src/app/admin/jobs/page.tsx
+++ b/frontend/src/app/admin/jobs/page.tsx
@@ -94,10 +94,10 @@ function JobsContent() {
     <Layout>
       <div className="max-w-6xl mx-auto">
         {/* Header */}
-        <div className="flex items-center gap-3 mb-6">
-          <ShieldAlert className="h-6 w-6 text-red-600" />
-          <h1 className="text-2xl font-bold text-gray-900">Modération des offres</h1>
-          <span className="ml-auto text-sm text-gray-500">{total} offre(s)</span>
+        <div className="mb-6 flex items-center gap-3">
+          <span className="flex h-10 w-10 items-center justify-center rounded-xl bg-gradient-to-br from-red-500 to-rose-600 text-white shadow-lg shadow-rose-200/50"><ShieldAlert className="h-5 w-5" /></span>
+          <h1 className="font-display text-2xl font-extrabold text-gray-900 sm:text-3xl">Modération des offres</h1>
+          <span className="ml-auto text-sm font-medium text-gray-500">{total} offre(s)</span>
         </div>
 
         {/* Filters */}
@@ -118,7 +118,7 @@ function JobsContent() {
         )}
 
         {/* Table */}
-        <div className="rounded-xl border border-gray-200 bg-white shadow-sm overflow-hidden">
+        <div className="card-premium overflow-hidden p-0">
           <table className="w-full text-sm">
             <thead className="bg-gray-50 border-b border-gray-200">
               <tr>

--- a/frontend/src/app/admin/monitoring/page.tsx
+++ b/frontend/src/app/admin/monitoring/page.tsx
@@ -49,12 +49,15 @@ export default function AdminMonitoringPage() {
   return (
     <AdminGuard>
       <Layout>
-        <div className="mb-6 flex items-center justify-between">
-          <div>
-            <h1 className="text-2xl font-bold text-gray-900">Logs & performances</h1>
-            <p className="text-gray-600">Supervision du système et journal d&apos;activité</p>
+        <div className="mb-6 flex items-center justify-between gap-3">
+          <div className="flex items-center gap-3">
+            <span className="flex h-10 w-10 items-center justify-center rounded-xl bg-gradient-to-br from-slate-700 to-slate-900 text-white shadow-lg"><Database className="h-5 w-5" /></span>
+            <div>
+              <h1 className="font-display text-2xl font-extrabold text-gray-900 sm:text-3xl">Logs &amp; performances</h1>
+              <p className="text-sm text-gray-500">Supervision du système et journal d&apos;activité</p>
+            </div>
           </div>
-          <button onClick={load} className="inline-flex items-center gap-2 rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-semibold text-gray-700 hover:bg-gray-50">
+          <button onClick={load} className="btn-ghost !py-2 text-sm">
             <RefreshCw className={`h-4 w-4 ${loading ? "animate-spin" : ""}`} /> Actualiser
           </button>
         </div>
@@ -66,8 +69,8 @@ export default function AdminMonitoringPage() {
         {/* Santé système */}
         {health && (
           <div className="mb-8 grid gap-6 lg:grid-cols-3">
-            <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
-              <h2 className="mb-4 text-lg font-semibold text-gray-900">État du système</h2>
+            <div className="card-premium p-6">
+              <h2 className="font-display mb-4 text-lg font-bold text-gray-900">État du système</h2>
               <div className="space-y-3 text-sm">
                 <div className="flex items-center justify-between">
                   <span className="text-gray-600">Statut global</span>
@@ -86,8 +89,8 @@ export default function AdminMonitoringPage() {
               </div>
             </div>
 
-            <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
-              <h2 className="mb-4 text-lg font-semibold text-gray-900">Capacités IA</h2>
+            <div className="card-premium p-6">
+              <h2 className="font-display mb-4 text-lg font-bold text-gray-900">Capacités IA</h2>
               <div className="space-y-2 text-sm">
                 {Object.entries(health.capabilities).length === 0 && (
                   <p className="text-gray-400">Aucune information</p>
@@ -108,8 +111,8 @@ export default function AdminMonitoringPage() {
               </div>
             </div>
 
-            <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
-              <h2 className="mb-4 text-lg font-semibold text-gray-900">Volumétrie</h2>
+            <div className="card-premium p-6">
+              <h2 className="font-display mb-4 text-lg font-bold text-gray-900">Volumétrie</h2>
               <div className="grid grid-cols-2 gap-3 text-sm">
                 {Object.entries(health.counts).map(([k, v]) => (
                   <div key={k} className="rounded-lg bg-gray-50 px-3 py-2">
@@ -123,9 +126,9 @@ export default function AdminMonitoringPage() {
         )}
 
         {/* Journal d'activité */}
-        <div className="rounded-xl border border-gray-200 bg-white shadow-sm">
+        <div className="card-premium overflow-hidden p-0">
           <div className="flex items-center justify-between border-b border-gray-100 px-5 py-4">
-            <h2 className="text-lg font-semibold text-gray-900">Journal d&apos;activité</h2>
+            <h2 className="font-display text-lg font-bold text-gray-900">Journal d&apos;activité</h2>
             <select
               value={levelFilter}
               onChange={(e) => setLevelFilter(e.target.value)}

--- a/frontend/src/app/admin/pipeline/page.tsx
+++ b/frontend/src/app/admin/pipeline/page.tsx
@@ -120,12 +120,12 @@ export default function AdminPipelinePage() {
     <AdminGuard>
       <Layout>
         <div className="mb-6 flex items-center gap-3">
-          <span className="flex h-11 w-11 items-center justify-center rounded-xl bg-rose-100 text-rose-600">
+          <span className="flex h-11 w-11 items-center justify-center rounded-xl bg-gradient-to-br from-rose-500 to-red-600 text-white shadow-lg shadow-rose-200/50">
             <SlidersVertical className="h-6 w-6" />
           </span>
           <div>
-            <h1 className="text-2xl font-bold text-gray-900">Paramètres du pipeline IA</h1>
-            <p className="text-gray-600">Poids du scoring et seuils de décision du matching</p>
+            <h1 className="font-display text-2xl font-extrabold text-gray-900 sm:text-3xl">Paramètres du pipeline IA</h1>
+            <p className="text-sm text-gray-500">Poids du scoring et seuils de décision du matching</p>
           </div>
         </div>
 
@@ -136,9 +136,9 @@ export default function AdminPipelinePage() {
           <div className="h-64 animate-pulse rounded-xl bg-gray-100" />
         ) : (
           <div className="space-y-6">
-            <section className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+            <section className="card-premium p-6">
               <div className="mb-4 flex items-center justify-between">
-                <h2 className="text-lg font-semibold text-gray-900">Poids du scoring</h2>
+                <h2 className="font-display text-lg font-bold text-gray-900">Poids du scoring</h2>
                 <span className={`rounded-full px-3 py-1 text-xs font-medium ${Math.abs(weightSum - 1) < 0.001 ? "bg-emerald-100 text-emerald-700" : "bg-amber-100 text-amber-700"}`}>
                   Somme des poids : {weightSum.toFixed(2)}
                 </span>
@@ -154,8 +154,8 @@ export default function AdminPipelinePage() {
               </div>
             </section>
 
-            <section className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
-              <h2 className="mb-4 text-lg font-semibold text-gray-900">Seuils de décision</h2>
+            <section className="card-premium p-6">
+              <h2 className="font-display mb-4 text-lg font-bold text-gray-900">Seuils de décision</h2>
               {thresholdInvalid && (
                 <p className="mb-4 flex items-center gap-2 text-xs text-red-600">
                   <AlertTriangle className="h-4 w-4" />
@@ -168,18 +168,10 @@ export default function AdminPipelinePage() {
             </section>
 
             <div className="flex justify-end gap-3">
-              <button
-                onClick={reset}
-                disabled={saving}
-                className="inline-flex items-center gap-2 rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-semibold text-gray-700 hover:bg-gray-50 disabled:opacity-60"
-              >
+              <button onClick={reset} disabled={saving} className="btn-ghost !py-2 text-sm disabled:opacity-60">
                 <RotateCcw className="h-4 w-4" /> Réinitialiser
               </button>
-              <button
-                onClick={save}
-                disabled={saving || thresholdInvalid}
-                className="inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-5 py-2 text-sm font-semibold text-white hover:bg-indigo-700 disabled:opacity-60"
-              >
+              <button onClick={save} disabled={saving || thresholdInvalid} className="btn-primary !py-2 text-sm disabled:opacity-60">
                 <Save className="h-4 w-4" /> {saving ? "Enregistrement…" : "Enregistrer"}
               </button>
             </div>

--- a/frontend/src/app/admin/users/page.tsx
+++ b/frontend/src/app/admin/users/page.tsx
@@ -83,10 +83,10 @@ function UsersContent() {
     <Layout>
       <div className="max-w-6xl mx-auto">
         {/* Header */}
-        <div className="flex items-center gap-3 mb-6">
-          <ShieldAlert className="h-6 w-6 text-red-600" />
-          <h1 className="text-2xl font-bold text-gray-900">Gestion des utilisateurs</h1>
-          <span className="ml-auto text-sm text-gray-500">{total} utilisateur(s)</span>
+        <div className="mb-6 flex items-center gap-3">
+          <span className="flex h-10 w-10 items-center justify-center rounded-xl bg-gradient-to-br from-red-500 to-rose-600 text-white shadow-lg shadow-rose-200/50"><ShieldAlert className="h-5 w-5" /></span>
+          <h1 className="font-display text-2xl font-extrabold text-gray-900 sm:text-3xl">Gestion des utilisateurs</h1>
+          <span className="ml-auto text-sm font-medium text-gray-500">{total} utilisateur(s)</span>
         </div>
 
         {/* Filters */}
@@ -108,7 +108,7 @@ function UsersContent() {
         )}
 
         {/* Table */}
-        <div className="rounded-xl border border-gray-200 bg-white shadow-sm overflow-hidden">
+        <div className="card-premium overflow-hidden p-0">
           <table className="w-full text-sm">
             <thead className="bg-gray-50 border-b border-gray-200">
               <tr>

--- a/frontend/src/app/auth/login/page.tsx
+++ b/frontend/src/app/auth/login/page.tsx
@@ -3,15 +3,10 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
-import { ArrowRight, CheckCircle2, Sparkles } from 'lucide-react';
-import { Manrope } from 'next/font/google';
+import { ArrowRight, ShieldCheck, Sparkles, Zap } from 'lucide-react';
 import { authApi } from '@/services/auth';
 import { getErrorMessage } from '@/utils/errorHandler';
-
-const manrope = Manrope({
-  subsets: ['latin'],
-  weight: ['500', '600', '700', '800'],
-});
+import ThemeToggle from '@/components/ThemeToggle';
 
 export default function LoginPage() {
   const router = useRouter();
@@ -49,56 +44,65 @@ export default function LoginPage() {
   };
 
   return (
-    <div className={`${manrope.className} relative min-h-screen overflow-hidden bg-slate-50 text-slate-900`}>
-      <div className="pointer-events-none absolute inset-0 -z-10">
-        <div className="absolute -top-24 -left-16 h-72 w-72 rounded-full bg-blue-300/30 blur-3xl" />
-        <div className="absolute bottom-0 right-0 h-80 w-80 rounded-full bg-indigo-300/30 blur-3xl" />
+    <div className="relative min-h-screen overflow-hidden bg-slate-50 text-slate-900">
+      {/* Aurora background */}
+      <div className="aurora">
+        <div className="aurora-orb left-[-8%] top-[-6%] h-80 w-80 bg-blue-400" />
+        <div className="aurora-orb right-[-6%] bottom-[2%] h-96 w-96 bg-violet-400" style={{ animationDelay: '-5s' }} />
+        <div className="grid-overlay absolute inset-0 opacity-50" />
       </div>
 
-      <nav className="border-b border-slate-200/70 bg-white/80 backdrop-blur-xl">
-        <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-4 sm:px-6 lg:px-8">
+      <nav className="glass-nav border-b border-slate-200 backdrop-blur-xl">
+        <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-3.5 sm:px-6 lg:px-8">
           <Link href="/" className="flex items-center gap-3">
-            <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-gradient-to-br from-blue-600 to-indigo-600 text-white shadow-md shadow-blue-200">
+            <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-gradient-to-br from-blue-600 to-indigo-600 text-white shadow-lg shadow-indigo-300/50">
               <Sparkles className="h-5 w-5" />
             </div>
             <div>
-              <p className="text-xs font-semibold uppercase tracking-widest text-slate-500">AI Recruiting</p>
-              <p className="text-lg font-bold">AI Talent Finder</p>
+              <p className="text-[0.7rem] font-bold uppercase tracking-[0.18em] text-indigo-600">AI Recruiting</p>
+              <p className="font-display text-lg font-bold leading-none text-slate-900">AI Talent Finder</p>
             </div>
           </Link>
-          <Link href="/" className="text-sm font-semibold text-slate-600 transition hover:text-slate-900">
-            Retour a l'accueil
-          </Link>
+          <div className="flex items-center gap-3">
+            <ThemeToggle />
+            <Link href="/" className="text-sm font-semibold text-slate-700 transition hover:text-indigo-600">
+              Retour à l&apos;accueil
+            </Link>
+          </div>
         </div>
       </nav>
 
-      <div className="mx-auto grid min-h-[calc(100vh-72px)] w-full max-w-6xl gap-8 px-4 py-10 sm:px-6 lg:grid-cols-2 lg:items-center lg:px-8">
-        <aside className="rounded-3xl border border-slate-200 bg-white p-8 shadow-xl shadow-slate-100">
-          <span className="inline-flex items-center gap-2 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-xs font-semibold text-blue-700">
-            <CheckCircle2 className="h-4 w-4" />
-            Espace securise
-          </span>
-          <h1 className="mt-4 text-4xl font-extrabold leading-tight text-slate-900">
-            Connecte-toi a
-            <span className="block bg-gradient-to-r from-blue-600 to-indigo-600 bg-clip-text text-transparent">
-              ton espace intelligent
-            </span>
+      <div className="mx-auto grid min-h-[calc(100vh-69px)] w-full max-w-6xl items-center gap-10 px-4 py-12 sm:px-6 lg:grid-cols-2 lg:px-8">
+        {/* Left brand panel */}
+        <aside className="hidden lg:block anim-fade-up">
+          <span className="pill mb-5"><ShieldCheck className="h-3.5 w-3.5" /> Espace sécurisé</span>
+          <h1 className="font-display text-5xl font-extrabold leading-[1.05] text-slate-900">
+            Connecte-toi à
+            <span className="block gradient-text">ton espace intelligent</span>
           </h1>
-          <p className="mt-4 text-slate-600">
-            Accede a ton dashboard recruteur ou candidat, avec suivi de matching et actions prioritaires.
+          <p className="mt-5 max-w-md text-lg text-slate-600">
+            Accède à ton dashboard recruteur ou candidat, avec suivi de matching et actions prioritaires.
           </p>
 
-          <div className="mt-8 space-y-3 text-sm text-slate-600">
-            <p className="rounded-lg border-l-4 border-blue-500 bg-blue-50 px-4 py-3">Recommandations en temps reel.</p>
-            <p className="rounded-lg border-l-4 border-indigo-500 bg-indigo-50 px-4 py-3">Parcours candidat et recruteur unifie.</p>
-            <p className="rounded-lg border-l-4 border-emerald-500 bg-emerald-50 px-4 py-3">Authentification JWT et acces controle.</p>
+          <div className="mt-9 space-y-3">
+            {[
+              { icon: <Zap className="h-4 w-4" />, c: 'from-blue-500 to-indigo-500', t: 'Recommandations en temps réel.' },
+              { icon: <Sparkles className="h-4 w-4" />, c: 'from-violet-500 to-fuchsia-500', t: 'Parcours candidat et recruteur unifié.' },
+              { icon: <ShieldCheck className="h-4 w-4" />, c: 'from-emerald-500 to-teal-500', t: 'Authentification JWT et accès contrôlé.' },
+            ].map((x) => (
+              <div key={x.t} className="glass-panel flex items-center gap-3 rounded-xl px-4 py-3">
+                <span className={`flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg bg-gradient-to-br text-white ${x.c}`}>{x.icon}</span>
+                <span className="text-sm font-medium text-slate-700">{x.t}</span>
+              </div>
+            ))}
           </div>
         </aside>
 
-        <div className="rounded-3xl border border-slate-200 bg-white p-8 shadow-xl shadow-slate-100">
-          <div className="mb-6">
-            <h2 className="text-3xl font-extrabold text-slate-900">Se connecter</h2>
-            <p className="mt-1 text-slate-600">Accedez a votre compte</p>
+        {/* Login card */}
+        <div className="card-premium anim-pop p-8 sm:p-9">
+          <div className="mb-7">
+            <h2 className="font-display text-3xl font-extrabold text-slate-900">Se connecter</h2>
+            <p className="mt-1.5 text-slate-600">Accédez à votre compte</p>
           </div>
 
           <form onSubmit={handleSubmit} className="space-y-5">
@@ -112,7 +116,7 @@ export default function LoginPage() {
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
                 placeholder="votre@email.com"
-                className="w-full rounded-xl border border-slate-300 bg-white px-4 py-3 text-slate-900 outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+                className="w-full rounded-xl border border-slate-300 bg-white px-4 py-3 text-slate-900 outline-none transition focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200"
                 required
                 aria-required="true"
               />
@@ -128,7 +132,7 @@ export default function LoginPage() {
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
                 placeholder="••••••••"
-                className="w-full rounded-xl border border-slate-300 bg-white px-4 py-3 text-slate-900 outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+                className="w-full rounded-xl border border-slate-300 bg-white px-4 py-3 text-slate-900 outline-none transition focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200"
                 required
                 minLength={6}
                 aria-required="true"
@@ -150,31 +154,26 @@ export default function LoginPage() {
               type="submit"
               disabled={isLoading}
               aria-label="Se connecter à ton compte"
-              className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-gradient-to-r from-blue-600 to-indigo-600 px-6 py-3 font-semibold text-white transition hover:from-blue-700 hover:to-indigo-700 disabled:cursor-not-allowed disabled:opacity-70"
+              className="btn-primary w-full disabled:cursor-not-allowed disabled:opacity-70"
             >
               {isLoading ? 'Connexion...' : 'Se connecter'}
               {!isLoading && <ArrowRight className="h-4 w-4" />}
             </button>
           </form>
 
+          <div className="mt-6 flex items-center gap-3 text-xs text-slate-400">
+            <span className="h-px flex-1 bg-slate-200" /> ou <span className="h-px flex-1 bg-slate-200" />
+          </div>
+
           <div className="mt-6 text-center text-sm text-slate-600">
             Pas encore de compte ?{' '}
             <Link
               href="/auth/register"
               aria-label="Aller à la page de création de compte"
-              className="font-semibold text-blue-700 transition hover:text-blue-800"
+              className="font-semibold text-indigo-600 transition hover:text-indigo-700"
             >
               Créer un compte
             </Link>
-          </div>
-
-          <div className="mt-8 rounded-xl border border-blue-200 bg-blue-50 p-4 text-xs text-blue-900">
-            <p className="mb-2 font-semibold">Comptes de test :</p>
-            <ul className="space-y-1">
-              <li><strong>Candidat:</strong> alice@test.com / password123</li>
-              <li><strong>Recruteur:</strong> bob@test.com / password123</li>
-              <li><strong>Admin:</strong> admin@test.com / password123</li>
-            </ul>
           </div>
         </div>
       </div>

--- a/frontend/src/app/auth/register/page.tsx
+++ b/frontend/src/app/auth/register/page.tsx
@@ -3,15 +3,10 @@
 import { useState, Suspense } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
-import { ArrowRight, CheckCircle2, Sparkles } from 'lucide-react';
-import { Manrope } from 'next/font/google';
+import { ArrowRight, Briefcase, Rocket, Sparkles, UserRound, Zap } from 'lucide-react';
 import { authApi } from '@/services/auth';
 import { getErrorMessage } from '@/utils/errorHandler';
-
-const manrope = Manrope({
-  subsets: ['latin'],
-  weight: ['500', '600', '700', '800'],
-});
+import ThemeToggle from '@/components/ThemeToggle';
 
 function RegisterForm() {
   const router = useRouter();
@@ -58,56 +53,65 @@ function RegisterForm() {
   };
 
   return (
-    <div className={`${manrope.className} relative min-h-screen overflow-hidden bg-slate-50 text-slate-900`}>
-      <div className="pointer-events-none absolute inset-0 -z-10">
-        <div className="absolute -top-24 -left-16 h-72 w-72 rounded-full bg-blue-300/30 blur-3xl" />
-        <div className="absolute bottom-0 right-0 h-80 w-80 rounded-full bg-indigo-300/30 blur-3xl" />
+    <div className="relative min-h-screen overflow-hidden bg-slate-50 text-slate-900">
+      {/* Aurora background */}
+      <div className="aurora">
+        <div className="aurora-orb left-[-8%] top-[-6%] h-80 w-80 bg-blue-400" />
+        <div className="aurora-orb right-[-6%] bottom-[2%] h-96 w-96 bg-violet-400" style={{ animationDelay: '-5s' }} />
+        <div className="grid-overlay absolute inset-0 opacity-50" />
       </div>
 
-      <nav className="border-b border-slate-200/70 bg-white/80 backdrop-blur-xl">
-        <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-4 sm:px-6 lg:px-8">
+      <nav className="glass-nav border-b border-slate-200 backdrop-blur-xl">
+        <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-3.5 sm:px-6 lg:px-8">
           <Link href="/" className="flex items-center gap-3">
-            <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-gradient-to-br from-blue-600 to-indigo-600 text-white shadow-md shadow-blue-200">
+            <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-gradient-to-br from-blue-600 to-indigo-600 text-white shadow-lg shadow-indigo-300/50">
               <Sparkles className="h-5 w-5" />
             </div>
             <div>
-              <p className="text-xs font-semibold uppercase tracking-widest text-slate-500">AI Recruiting</p>
-              <p className="text-lg font-bold">AI Talent Finder</p>
+              <p className="text-[0.7rem] font-bold uppercase tracking-[0.18em] text-indigo-600">AI Recruiting</p>
+              <p className="font-display text-lg font-bold leading-none text-slate-900">AI Talent Finder</p>
             </div>
           </Link>
-          <Link href="/" className="text-sm font-semibold text-slate-600 transition hover:text-slate-900">
-            Retour a l'accueil
-          </Link>
+          <div className="flex items-center gap-3">
+            <ThemeToggle />
+            <Link href="/" className="text-sm font-semibold text-slate-700 transition hover:text-indigo-600">
+              Retour à l&apos;accueil
+            </Link>
+          </div>
         </div>
       </nav>
 
-      <div className="mx-auto grid min-h-[calc(100vh-72px)] w-full max-w-6xl gap-8 px-4 py-10 sm:px-6 lg:grid-cols-2 lg:items-center lg:px-8">
-        <aside className="rounded-3xl border border-slate-200 bg-white p-8 shadow-xl shadow-slate-100">
-          <span className="inline-flex items-center gap-2 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-xs font-semibold text-blue-700">
-            <CheckCircle2 className="h-4 w-4" />
-            Onboarding rapide
-          </span>
-          <h1 className="mt-4 text-4xl font-extrabold leading-tight text-slate-900">
-            Cree ton compte
-            <span className="block bg-gradient-to-r from-blue-600 to-indigo-600 bg-clip-text text-transparent">
-              et active ton espace
-            </span>
+      <div className="mx-auto grid min-h-[calc(100vh-69px)] w-full max-w-6xl items-center gap-10 px-4 py-12 sm:px-6 lg:grid-cols-2 lg:px-8">
+        {/* Left brand panel */}
+        <aside className="hidden lg:block anim-fade-up">
+          <span className="pill mb-5"><Rocket className="h-3.5 w-3.5" /> Onboarding rapide</span>
+          <h1 className="font-display text-5xl font-extrabold leading-[1.05] text-slate-900">
+            Crée ton compte
+            <span className="block gradient-text">et active ton espace</span>
           </h1>
-          <p className="mt-4 text-slate-600">
-            Choisis ton parcours candidat ou recruteur et commence a exploiter le matching IA en quelques minutes.
+          <p className="mt-5 max-w-md text-lg text-slate-600">
+            Choisis ton parcours candidat ou recruteur et commence à exploiter le matching IA en quelques minutes.
           </p>
 
-          <div className="mt-8 space-y-3 text-sm text-slate-600">
-            <p className="rounded-lg border-l-4 border-blue-500 bg-blue-50 px-4 py-3">Inscription en moins de 60 secondes.</p>
-            <p className="rounded-lg border-l-4 border-purple-500 bg-purple-50 px-4 py-3">Experience adaptee a votre role.</p>
-            <p className="rounded-lg border-l-4 border-emerald-500 bg-emerald-50 px-4 py-3">Acces instantane au dashboard.</p>
+          <div className="mt-9 space-y-3">
+            {[
+              { icon: <Zap className="h-4 w-4" />, c: 'from-blue-500 to-indigo-500', t: 'Inscription en moins de 60 secondes.' },
+              { icon: <Sparkles className="h-4 w-4" />, c: 'from-violet-500 to-fuchsia-500', t: 'Expérience adaptée à votre rôle.' },
+              { icon: <Rocket className="h-4 w-4" />, c: 'from-emerald-500 to-teal-500', t: 'Accès instantané au dashboard.' },
+            ].map((x) => (
+              <div key={x.t} className="glass-panel flex items-center gap-3 rounded-xl px-4 py-3">
+                <span className={`flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg bg-gradient-to-br text-white ${x.c}`}>{x.icon}</span>
+                <span className="text-sm font-medium text-slate-700">{x.t}</span>
+              </div>
+            ))}
           </div>
         </aside>
 
-        <div className="rounded-3xl border border-slate-200 bg-white p-8 shadow-xl shadow-slate-100">
+        {/* Register card */}
+        <div className="card-premium anim-pop p-8 sm:p-9">
           <div className="mb-6">
-            <h2 className="text-3xl font-extrabold text-slate-900">Creer un compte</h2>
-            <p className="mt-1 text-slate-600">Choisissez votre parcours</p>
+            <h2 className="font-display text-3xl font-extrabold text-slate-900">Créer un compte</h2>
+            <p className="mt-1.5 text-slate-600">Choisissez votre parcours</p>
           </div>
 
           <div className="mb-6 grid gap-3 md:grid-cols-2" role="group" aria-label="Sélectionnez votre rôle">
@@ -116,13 +120,15 @@ function RegisterForm() {
               role="radio"
               aria-checked={role === 'candidate'}
               aria-label="Candidat: Mettez votre CV en avant"
-              className={`rounded-xl border-2 p-4 text-left transition focus:outline-none focus:ring-2 ${
+              className={`group rounded-2xl border-2 p-4 text-left transition focus:outline-none focus:ring-2 ${
                 role === 'candidate'
-                  ? 'border-blue-600 bg-blue-50 focus:ring-blue-300'
+                  ? 'border-blue-600 bg-blue-50 shadow-md shadow-blue-100 focus:ring-blue-300'
                   : 'border-slate-200 bg-white hover:border-blue-300 focus:ring-blue-200'
               }`}
             >
-              <div className="text-2xl" aria-hidden="true">👤</div>
+              <div className={`inline-flex h-9 w-9 items-center justify-center rounded-lg transition ${role === 'candidate' ? 'bg-blue-600 text-white' : 'bg-blue-100 text-blue-600'}`}>
+                <UserRound className="h-5 w-5" />
+              </div>
               <h3 className="mt-2 font-bold text-slate-900">Candidat</h3>
               <p className="text-sm text-slate-600">Mettez vos talents en avant</p>
             </button>
@@ -132,13 +138,15 @@ function RegisterForm() {
               role="radio"
               aria-checked={role === 'recruiter'}
               aria-label="Recruteur: Trouvez les meilleurs talents"
-              className={`rounded-xl border-2 p-4 text-left transition focus:outline-none focus:ring-2 ${
+              className={`group rounded-2xl border-2 p-4 text-left transition focus:outline-none focus:ring-2 ${
                 role === 'recruiter'
-                  ? 'border-purple-600 bg-purple-50 focus:ring-purple-300'
-                  : 'border-slate-200 bg-white hover:border-purple-300 focus:ring-purple-200'
+                  ? 'border-violet-600 bg-violet-50 shadow-md shadow-violet-100 focus:ring-violet-300'
+                  : 'border-slate-200 bg-white hover:border-violet-300 focus:ring-violet-200'
               }`}
             >
-              <div className="text-2xl" aria-hidden="true">🧑‍💼</div>
+              <div className={`inline-flex h-9 w-9 items-center justify-center rounded-lg transition ${role === 'recruiter' ? 'bg-violet-600 text-white' : 'bg-violet-100 text-violet-600'}`}>
+                <Briefcase className="h-5 w-5" />
+              </div>
               <h3 className="mt-2 font-bold text-slate-900">Recruteur</h3>
               <p className="text-sm text-slate-600">Trouvez les meilleurs talents</p>
             </button>
@@ -155,7 +163,7 @@ function RegisterForm() {
                 value={fullName}
                 onChange={(e) => setFullName(e.target.value)}
                 placeholder="Jean Dupont"
-                className="w-full rounded-xl border border-slate-300 bg-white px-4 py-3 text-slate-900 outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+                className="w-full rounded-xl border border-slate-300 bg-white px-4 py-3 text-slate-900 outline-none transition focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200"
                 required
                 aria-required="true"
               />
@@ -171,7 +179,7 @@ function RegisterForm() {
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
                 placeholder="votre@email.com"
-                className="w-full rounded-xl border border-slate-300 bg-white px-4 py-3 text-slate-900 outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+                className="w-full rounded-xl border border-slate-300 bg-white px-4 py-3 text-slate-900 outline-none transition focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200"
                 required
                 aria-required="true"
               />
@@ -187,7 +195,7 @@ function RegisterForm() {
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
                 placeholder="••••••••"
-                className="w-full rounded-xl border border-slate-300 bg-white px-4 py-3 text-slate-900 outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+                className="w-full rounded-xl border border-slate-300 bg-white px-4 py-3 text-slate-900 outline-none transition focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200"
                 required
                 minLength={6}
                 aria-required="true"
@@ -213,11 +221,7 @@ function RegisterForm() {
               type="submit"
               disabled={isLoading}
               aria-label={`Créer mon compte en tant que ${role === 'candidate' ? 'candidat' : 'recruteur'}`}
-              className={`inline-flex w-full items-center justify-center gap-2 rounded-xl px-6 py-3 font-semibold text-white transition disabled:cursor-not-allowed disabled:opacity-70 ${
-                role === 'candidate'
-                  ? 'bg-gradient-to-r from-blue-600 to-cyan-600 hover:from-blue-700 hover:to-cyan-700'
-                  : 'bg-gradient-to-r from-indigo-600 to-purple-600 hover:from-indigo-700 hover:to-purple-700'
-              }`}
+              className="btn-primary w-full disabled:cursor-not-allowed disabled:opacity-70"
             >
               {isLoading ? 'Inscription...' : 'Créer mon compte'}
               {!isLoading && <ArrowRight className="h-4 w-4" />}
@@ -229,7 +233,7 @@ function RegisterForm() {
             <Link
               href="/auth/login"
               aria-label="Aller à la page de connexion"
-              className="font-semibold text-blue-700 transition hover:text-blue-800"
+              className="font-semibold text-indigo-600 transition hover:text-indigo-700"
             >
               Se connecter
             </Link>

--- a/frontend/src/app/candidate/dashboard/page.tsx
+++ b/frontend/src/app/candidate/dashboard/page.tsx
@@ -83,22 +83,23 @@ export default function CandidateDashboard() {
 {/* Main Content */}
       <div className="max-w-6xl mx-auto">
         {/* Welcome Card */}
-        <div className="bg-white rounded-xl shadow-md p-8 mb-8 border-l-4 border-blue-500">
-          <div className="flex items-start justify-between">
+        <div className="relative mb-8 overflow-hidden rounded-3xl bg-gradient-to-br from-blue-600 via-indigo-600 to-violet-600 p-8 text-white shadow-xl shadow-indigo-300/30">
+          <div className="absolute -right-8 -top-10 h-44 w-44 rounded-full bg-white/10 blur-2xl" />
+          <div className="relative flex items-start justify-between gap-4">
             <div>
-              <h2 className="text-3xl font-bold text-gray-900 mb-2">
+              <h2 className="font-display text-3xl font-extrabold sm:text-4xl">
                 Bienvenue, {user?.full_name}! 👋
               </h2>
-              <p className="text-gray-600 text-lg">
+              <p className="mt-1.5 max-w-xl text-indigo-100">
                 Mets en avant ton profil et tes compétences pour attirer les meilleurs recruteurs
               </p>
             </div>
             {candidate && candidate.extraction_quality_score && (
-              <div className="text-right">
-                <div className="text-3xl font-bold text-green-600">
+              <div className="flex-shrink-0 rounded-2xl bg-white/15 px-5 py-3 text-center backdrop-blur">
+                <div className="font-display text-3xl font-extrabold">
                   {formatPercent(candidate.extraction_quality_score)}%
                 </div>
-                <div className="text-sm text-gray-600">Profil complet</div>
+                <div className="text-xs text-indigo-100">Profil complet</div>
               </div>
             )}
           </div>
@@ -106,11 +107,11 @@ export default function CandidateDashboard() {
 
         {/* Quick Actions - Onboarding Steps */}
         <div className="mb-12">
-          <h3 className="text-2xl font-bold text-gray-900 mb-6">Étapes de configuration</h3>
+          <h3 className="font-display text-2xl font-bold text-gray-900 mb-6">Étapes de configuration</h3>
           <div className="grid md:grid-cols-3 gap-6">
             {/* Step 1: Upload CV */}
             <Link href="/candidate/upload">
-              <div className="bg-white rounded-xl shadow-md p-6 hover:shadow-xl transition-all duration-300 cursor-pointer group h-full">
+              <div className="card-premium card-glow group h-full cursor-pointer p-6">
                 <div className="flex items-start justify-between mb-4">
                   <div className="text-4xl group-hover:scale-110 transition-transform">📄</div>
                   <div className={`text-sm font-semibold px-3 py-1 rounded-full ${
@@ -131,7 +132,7 @@ export default function CandidateDashboard() {
 
             {/* Step 2: View Profile */}
             <Link href="/candidate/profile">
-              <div className="bg-white rounded-xl shadow-md p-6 hover:shadow-xl transition-all duration-300 cursor-pointer group h-full">
+              <div className="card-premium card-glow group h-full cursor-pointer p-6">
                 <div className="flex items-start justify-between mb-4">
                   <div className="text-4xl group-hover:scale-110 transition-transform">🧑</div>
                   <div className={`text-sm font-semibold px-3 py-1 rounded-full ${
@@ -183,9 +184,9 @@ export default function CandidateDashboard() {
 
         {/* Profile Stats */}
         <div className="mb-12">
-          <h3 className="text-2xl font-bold text-gray-900 mb-6">Ton Profil</h3>
+          <h3 className="font-display text-2xl font-bold text-gray-900 mb-6">Ton Profil</h3>
           <div className="grid md:grid-cols-4 gap-4">
-            <div className="bg-white rounded-xl shadow-md p-6 border-l-4 border-blue-500 hover:shadow-lg transition-shadow">
+            <div className="card-premium p-6 border-l-4 border-blue-500">
               <div className="flex items-center justify-between">
                 <div>
                   <div className="text-3xl font-bold text-blue-600">
@@ -202,7 +203,7 @@ export default function CandidateDashboard() {
               )}
             </div>
 
-            <div className="bg-white rounded-xl shadow-md p-6 border-l-4 border-green-500 hover:shadow-lg transition-shadow">
+            <div className="card-premium p-6 border-l-4 border-green-500">
               <div className="flex items-center justify-between">
                 <div>
                   <div className="text-3xl font-bold text-green-600">
@@ -225,7 +226,7 @@ export default function CandidateDashboard() {
               )}
             </div>
 
-            <div className="bg-white rounded-xl shadow-md p-6 border-l-4 border-purple-500 hover:shadow-lg transition-shadow">
+            <div className="card-premium p-6 border-l-4 border-purple-500">
               <div className="flex items-center justify-between">
                 <div>
                   <div className="text-3xl font-bold text-purple-600">
@@ -240,7 +241,7 @@ export default function CandidateDashboard() {
               </div>
             </div>
 
-            <div className="bg-white rounded-xl shadow-md p-6 border-l-4 border-orange-500 hover:shadow-lg transition-shadow">
+            <div className="card-premium p-6 border-l-4 border-orange-500">
               <div className="flex items-center justify-between">
                 <div>
                   <div className="text-3xl font-bold text-orange-600">0</div>

--- a/frontend/src/app/candidate/profile/edit/page.tsx
+++ b/frontend/src/app/candidate/profile/edit/page.tsx
@@ -105,8 +105,8 @@ export default function CandidateProfileEdit() {
     return (
       <Layout>
         <div className="max-w-2xl mx-auto">
-          <h1 className="text-2xl font-bold text-gray-900 mb-6">Éditer Mon Profil</h1>
-          <div className="bg-white rounded-lg shadow-md p-8">
+          <h1 className="font-display text-2xl font-bold text-gray-900 mb-6">Éditer Mon Profil</h1>
+          <div className="card-premium p-8">
             <SkeletonProfile />
           </div>
         </div>
@@ -118,7 +118,8 @@ export default function CandidateProfileEdit() {
     <Layout>
 {/* Main Content */}
       <div className="max-w-2xl mx-auto">
-        <div className="bg-white rounded-lg shadow-md p-8">
+        <h1 className="font-display text-2xl font-extrabold text-gray-900 mb-6">Éditer Mon Profil</h1>
+        <div className="card-premium p-8">
           {role === 'candidate' && !candidate && (
             <div className="mb-6 rounded-lg border border-amber-200 bg-amber-50 p-4 text-amber-800">
               <p className="font-semibold">Profil à créer manuellement</p>
@@ -163,7 +164,7 @@ export default function CandidateProfileEdit() {
                 onChange={(e) => setFullName(e.target.value)}
                 required
                 aria-required="true"
-                className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+                className="w-full rounded-xl border border-gray-300 bg-white px-4 py-3 outline-none transition focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200"
                 placeholder="Ex: Jean Dupont"
               />
             </div>
@@ -180,7 +181,7 @@ export default function CandidateProfileEdit() {
                 onChange={(e) => setEmail(e.target.value)}
                 required
                 aria-required="true"
-                className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+                className="w-full rounded-xl border border-gray-300 bg-white px-4 py-3 outline-none transition focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200"
                 placeholder="Ex: jean@example.com"
               />
             </div>
@@ -195,7 +196,7 @@ export default function CandidateProfileEdit() {
                 type="tel"
                 value={phone}
                 onChange={(e) => setPhone(e.target.value)}
-                className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+                className="w-full rounded-xl border border-gray-300 bg-white px-4 py-3 outline-none transition focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200"
                 placeholder="Ex: +33 6 12 34 56 78"
               />
             </div>
@@ -210,7 +211,7 @@ export default function CandidateProfileEdit() {
                 type="url"
                 value={linkedinUrl}
                 onChange={(e) => setLinkedinUrl(e.target.value)}
-                className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+                className="w-full rounded-xl border border-gray-300 bg-white px-4 py-3 outline-none transition focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200"
                 placeholder="Ex: https://linkedin.com/in/jean-dupont"
               />
               <p className="text-xs text-gray-500 mt-1">Optionnel - Votre profil LinkedIn complet</p>
@@ -226,7 +227,7 @@ export default function CandidateProfileEdit() {
                 type="url"
                 value={githubUrl}
                 onChange={(e) => setGithubUrl(e.target.value)}
-                className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+                className="w-full rounded-xl border border-gray-300 bg-white px-4 py-3 outline-none transition focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200"
                 placeholder="Ex: https://github.com/jean-dupont"
               />
               <p className="text-xs text-gray-500 mt-1">Optionnel - Votre profil GitHub</p>
@@ -245,14 +246,14 @@ export default function CandidateProfileEdit() {
                 type="submit"
                 disabled={saving}
                 aria-label={candidate ? 'Enregistrer les modifications du profil' : 'Créer mon profil'}
-                className="flex-1 px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 transition-colors font-medium focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="btn-primary flex-1 disabled:cursor-not-allowed disabled:opacity-50"
               >
                 {saving ? '💾 Enregistrement...' : candidate ? '💾 Enregistrer' : '💾 Créer mon profil'}
               </button>
               <Link
                 href="/candidate/profile"
                 aria-label="Annuler et retourner au profil"
-                className="flex-1 px-6 py-2 bg-gray-200 text-gray-900 rounded-lg hover:bg-gray-300 transition-colors font-medium text-center focus:outline-none focus:ring-2 focus:ring-gray-400 inline-flex items-center justify-center"
+                className="btn-ghost flex-1"
               >
                 Annuler
               </Link>

--- a/frontend/src/app/candidate/profile/page.tsx
+++ b/frontend/src/app/candidate/profile/page.tsx
@@ -76,7 +76,7 @@ export default function CandidateProfile() {
     return (
       <Layout>
         <div className="max-w-4xl mx-auto">
-          <h1 className="text-2xl font-bold text-blue-600 mb-6">🧑 Mon Profil</h1>
+          <h1 className="font-display text-2xl font-bold text-indigo-600 mb-6">🧑 Mon Profil</h1>
           <SkeletonProfile />
         </div>
       </Layout>
@@ -106,15 +106,15 @@ export default function CandidateProfile() {
       <Layout>
         <div className="flex items-center justify-center py-20">
           <div className="max-w-lg text-center">
-            <h2 className="text-2xl font-bold text-gray-900 mb-3">Aucun profil trouvé</h2>
+            <h2 className="font-display text-2xl font-bold text-gray-900 mb-3">Aucun profil trouvé</h2>
             <p className="text-gray-600 mb-6">
               Tu peux créer ton profil manuellement ou uploader un CV pour lancer l’extraction automatique.
             </p>
             <div className="flex flex-wrap gap-3 justify-center">
-              <Link href="/candidate/profile/edit" className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700">
+              <Link href="/candidate/profile/edit" className="btn-primary">
                 Créer mon profil
               </Link>
-              <Link href="/candidate/upload" className="bg-gray-200 text-gray-900 px-4 py-2 rounded hover:bg-gray-300">
+              <Link href="/candidate/upload" className="btn-ghost">
                 Uploader un CV
               </Link>
             </div>
@@ -217,17 +217,24 @@ export default function CandidateProfile() {
 {/* Content */}
       <div className="max-w-4xl mx-auto">
         {/* Profile Header Card */}
-        <div className="bg-white rounded-lg shadow-md p-8 mb-8">
-          <div className="flex justify-between items-start mb-6">
-            <div>
-              <h2 className="text-3xl font-bold text-gray-900 mb-2">
-                {candidate.extracted_name || candidate.full_name}
-              </h2>
-              <p className="text-gray-600">
-                {candidate.is_fully_extracted ? '✅ Profil extrait du CV' : '⚠️ Données partielles'}
-              </p>
+        <div className="card-premium overflow-hidden p-0 mb-8">
+          <div className="relative bg-gradient-to-br from-blue-600 via-indigo-600 to-violet-600 p-8 text-white">
+            <div className="absolute -right-8 -top-10 h-40 w-40 rounded-full bg-white/10 blur-2xl" />
+            <div className="relative flex items-center gap-5">
+              <div className="flex h-16 w-16 flex-shrink-0 items-center justify-center rounded-2xl bg-white/15 text-2xl font-extrabold backdrop-blur">
+                {((candidate.extracted_name || candidate.full_name) || 'C')[0].toUpperCase()}
+              </div>
+              <div>
+                <h2 className="font-display text-3xl font-extrabold">
+                  {candidate.extracted_name || candidate.full_name}
+                </h2>
+                <p className="mt-0.5 text-indigo-100">
+                  {candidate.is_fully_extracted ? '✅ Profil extrait du CV' : '⚠️ Données partielles'}
+                </p>
+              </div>
             </div>
           </div>
+          <div className="p-8">
 
           {/* Quality Score */}
           {candidate.extraction_quality_score && (
@@ -550,6 +557,7 @@ export default function CandidateProfile() {
                 </p>
               </div>
             </div>
+          </div>
           </div>
         </div>
       </div>

--- a/frontend/src/app/candidate/upload/page.tsx
+++ b/frontend/src/app/candidate/upload/page.tsx
@@ -86,26 +86,29 @@ export default function UploadCV() {
   return (
     <Layout>
 {/* Main Content */}
-      <div className="max-w-4xl mx-auto px-4 py-8">
+      <div className="max-w-4xl mx-auto">
         {/* Header */}
-        <div className="bg-white rounded-xl shadow-md p-8 mb-8 border-l-4 border-blue-500">
-          <h2 className="text-3xl font-bold text-gray-900 mb-2">Télécharge ton CV 📥</h2>
-          <p className="text-gray-600 text-lg">
-            Notre IA analysera ton CV et extraira automatiquement tes compétences, expériences et formations
-          </p>
+        <div className="relative mb-8 overflow-hidden rounded-3xl bg-gradient-to-br from-blue-600 via-indigo-600 to-violet-600 p-8 text-white shadow-xl shadow-indigo-300/30">
+          <div className="absolute -right-8 -top-10 h-44 w-44 rounded-full bg-white/10 blur-2xl" />
+          <div className="relative">
+            <h2 className="font-display text-3xl font-extrabold sm:text-4xl">Télécharge ton CV 📥</h2>
+            <p className="mt-1.5 max-w-2xl text-indigo-100">
+              Notre IA analysera ton CV et extraira automatiquement tes compétences, expériences et formations
+            </p>
+          </div>
         </div>
 
-        <div className="bg-white rounded-xl shadow-md p-8">
+        <div className="card-premium p-8">
           {/* Upload Area */}
           <div
             onDragEnter={handleDrag}
             onDragLeave={handleDrag}
             onDragOver={handleDrag}
             onDrop={handleDrop}
-            className={`border-2 border-dashed rounded-xl p-12 text-center cursor-pointer transition-all duration-300 ${
+            className={`rounded-2xl border-2 border-dashed p-12 text-center cursor-pointer transition-all duration-300 ${
               dragActive
-                ? 'border-blue-500 bg-blue-50 scale-105'
-                : 'border-gray-300 hover:border-blue-400 hover:bg-blue-50'
+                ? 'border-indigo-500 bg-indigo-50 scale-[1.02]'
+                : 'border-gray-300 hover:border-indigo-400 hover:bg-indigo-50/50'
             }`}
             role="region"
             aria-label="Zone de dépôt de fichier"
@@ -124,10 +127,7 @@ export default function UploadCV() {
               id="file-input"
               aria-label="Sélectionner un fichier PDF"
             />
-            <label
-              htmlFor="file-input"
-              className="inline-block bg-gradient-to-r from-blue-600 to-blue-700 text-white px-8 py-3 rounded-lg hover:from-blue-700 hover:to-blue-800 cursor-pointer font-semibold transition-all transform hover:scale-105 active:scale-95"
-            >
+            <label htmlFor="file-input" className="btn-primary inline-flex cursor-pointer">
               Parcourir les fichiers
             </label>
           </div>
@@ -186,11 +186,7 @@ export default function UploadCV() {
             <button
               onClick={handleUpload}
               disabled={!file || loading}
-              className={`px-8 py-3 rounded-lg font-semibold text-white transition-all transform disabled:opacity-50 disabled:cursor-not-allowed ${
-                loading
-                  ? 'bg-blue-500'
-                  : 'bg-gradient-to-r from-blue-600 to-blue-700 hover:from-blue-700 hover:to-blue-800 active:scale-95'
-              }`}
+              className="btn-primary disabled:cursor-not-allowed disabled:opacity-50"
               type="button"
               aria-label={loading ? 'Upload en cours' : 'Télécharger le CV'}
             >

--- a/frontend/src/app/candidates/[id]/page.tsx
+++ b/frontend/src/app/candidates/[id]/page.tsx
@@ -196,7 +196,7 @@ export default function CandidateDetail() {
       {/* Header */}
       <div className="max-w-4xl mx-auto mb-6 flex justify-between items-center">
         <Link href="/candidates" className="text-sm text-gray-500 hover:text-indigo-600">← Retour aux candidats</Link>
-        <h1 className="text-2xl font-bold text-gray-900">Profil Candidat</h1>
+        <h1 className="font-display text-2xl font-bold text-gray-900">Profil Candidat</h1>
         <button
           onClick={toggleFavorite}
           disabled={addingFavorite}
@@ -216,15 +216,25 @@ export default function CandidateDetail() {
           {/* Main Info */}
           <div className="md:col-span-2 space-y-6">
             {/* Header */}
-            <div className="bg-white rounded-lg shadow-md p-6">
-              <h2 className="text-3xl font-bold text-gray-900" id="candidate-header">
-                {candidate.full_name}
-              </h2>
-              <p className="text-gray-600 mt-1">{candidate.email}</p>
-              {candidate.phone && <p className="text-gray-600">{candidate.phone}</p>}
-
+            <div className="card-premium overflow-hidden p-0">
+              <div className="relative bg-gradient-to-br from-indigo-600 via-violet-600 to-indigo-700 p-6 text-white">
+                <div className="absolute -right-6 -top-8 h-32 w-32 rounded-full bg-white/10 blur-2xl" />
+                <div className="relative flex items-center gap-4">
+                  <div className="flex h-16 w-16 flex-shrink-0 items-center justify-center rounded-2xl bg-white/15 text-2xl font-extrabold backdrop-blur">
+                    {(candidate.full_name || 'C')[0].toUpperCase()}
+                  </div>
+                  <div className="min-w-0">
+                    <h2 className="font-display text-2xl font-extrabold sm:text-3xl" id="candidate-header">
+                      {candidate.full_name}
+                    </h2>
+                    <p className="mt-0.5 truncate text-indigo-100">{candidate.email}</p>
+                    {candidate.phone && <p className="text-sm text-indigo-200">{candidate.phone}</p>}
+                  </div>
+                </div>
+              </div>
+              <div className="p-6 pt-4">
               {/* Links */}
-              <div className="flex gap-4 mt-4">
+              <div className="flex gap-4">
                 {candidate.linkedin_url && (
                   <a
                     href={candidate.linkedin_url}
@@ -264,11 +274,12 @@ export default function CandidateDetail() {
                   </p>
                 </div>
               )}
+              </div>
             </div>
 
             {/* Job Titles */}
             {extractedJobTitles.length > 0 && (
-              <div className="bg-white rounded-lg shadow-md p-6" role="region" aria-labelledby="job-titles-heading">
+              <div className="card-premium p-6" role="region" aria-labelledby="job-titles-heading">
                 <h3 className="text-xl font-bold text-gray-900 mb-3" id="job-titles-heading">
                   💼 Titres de Poste
                 </h3>
@@ -288,7 +299,7 @@ export default function CandidateDetail() {
 
             {/* Companies */}
             {extractedCompanies.length > 0 && (
-              <div className="bg-white rounded-lg shadow-md p-6" role="region" aria-labelledby="companies-heading">
+              <div className="card-premium p-6" role="region" aria-labelledby="companies-heading">
                 <h3 className="text-xl font-bold text-gray-900 mb-3" id="companies-heading">
                   🏢 Compagnies
                 </h3>
@@ -308,7 +319,7 @@ export default function CandidateDetail() {
 
             {/* Education */}
             {extractedEducation.length > 0 && (
-              <div className="bg-white rounded-lg shadow-md p-6" role="region" aria-labelledby="education-heading">
+              <div className="card-premium p-6" role="region" aria-labelledby="education-heading">
                 <h3 className="text-xl font-bold text-gray-900 mb-3" id="education-heading">
                   🎓 Éducation
                 </h3>
@@ -328,7 +339,7 @@ export default function CandidateDetail() {
 
             {/* Profile Summary */}
             {profileSummary && (
-              <div className="mb-8 bg-white rounded-lg shadow-md p-6" role="region" aria-labelledby="summary-heading">
+              <div className="mb-8 card-premium p-6" role="region" aria-labelledby="summary-heading">
                 <h3 className="text-xl font-bold text-gray-900 mb-3" id="summary-heading">📝 Profil</h3>
                 <p className="text-gray-700 p-4 bg-indigo-50 rounded leading-relaxed">{profileSummary}</p>
               </div>
@@ -366,7 +377,7 @@ export default function CandidateDetail() {
 
             {/* Certifications & Projects */}
             <div className="grid md:grid-cols-2 gap-6 mb-8">
-              <div role="region" aria-labelledby="certifications-heading" className="bg-white rounded-lg shadow-md p-6">
+              <div role="region" aria-labelledby="certifications-heading" className="card-premium p-6">
                 <h3 className="text-lg font-bold text-gray-900 mb-3" id="certifications-heading">📜 Certifications</h3>
                 <div className="space-y-2" role="list">
                   {certifications.map((certification: string, idx: number) => (
@@ -375,7 +386,7 @@ export default function CandidateDetail() {
                   {certifications.length === 0 && <p className="text-gray-400">Aucune certification trouvée</p>}
                 </div>
               </div>
-              <div role="region" aria-labelledby="projects-heading" className="bg-white rounded-lg shadow-md p-6">
+              <div role="region" aria-labelledby="projects-heading" className="card-premium p-6">
                 <h3 className="text-lg font-bold text-gray-900 mb-3" id="projects-heading">🚀 Projets</h3>
                 <div className="space-y-2" role="list">
                   {projects.map((project: string, idx: number) => (
@@ -388,7 +399,7 @@ export default function CandidateDetail() {
 
             {/* Tech Skills */}
             {techSkills.length > 0 && (
-              <div className="mb-8 bg-white rounded-lg shadow-md p-6" role="region" aria-labelledby="tech-skills-heading">
+              <div className="mb-8 card-premium p-6" role="region" aria-labelledby="tech-skills-heading">
                 <h3 className="text-lg font-bold text-gray-900 mb-3" id="tech-skills-heading">⚙️ Compétences Techniques</h3>
                 <div className="flex flex-wrap gap-2" role="list">
                   {techSkills.map((skill: string, idx: number) => (
@@ -406,7 +417,7 @@ export default function CandidateDetail() {
 
             {/* Languages, Skills, Interests */}
             <div className="grid md:grid-cols-3 gap-6 mb-8">
-              <div role="region" aria-labelledby="languages-heading" className="bg-white rounded-lg shadow-md p-6">
+              <div role="region" aria-labelledby="languages-heading" className="card-premium p-6">
                 <h3 className="text-lg font-bold text-gray-900 mb-3" id="languages-heading">🌍 Langues</h3>
                 <div className="space-y-2" role="list">
                   {languages.map((language: string, idx: number) => (
@@ -415,7 +426,7 @@ export default function CandidateDetail() {
                   {languages.length === 0 && <p className="text-gray-400">Aucune langue trouvée</p>}
                 </div>
               </div>
-              <div role="region" aria-labelledby="soft-skills-heading" className="bg-white rounded-lg shadow-md p-6">
+              <div role="region" aria-labelledby="soft-skills-heading" className="card-premium p-6">
                 <h3 className="text-lg font-bold text-gray-900 mb-3" id="soft-skills-heading">🤝 Compétences</h3>
                 <div className="space-y-2" role="list">
                   {softSkills.map((skill: string, idx: number) => (
@@ -424,7 +435,7 @@ export default function CandidateDetail() {
                   {softSkills.length === 0 && <p className="text-gray-400">Aucune compétence trouvée</p>}
                 </div>
               </div>
-              <div role="region" aria-labelledby="interests-heading" className="bg-white rounded-lg shadow-md p-6">
+              <div role="region" aria-labelledby="interests-heading" className="card-premium p-6">
                 <h3 className="text-lg font-bold text-gray-900 mb-3" id="interests-heading">🎯 Centres d’intérêt</h3>
                 <div className="space-y-2" role="list">
                   {interests.map((interest: string, idx: number) => (
@@ -454,7 +465,7 @@ export default function CandidateDetail() {
           {/* Sidebar */}
           <div className="space-y-6">
             {/* Contact Info */}
-            <div className="bg-white rounded-lg shadow-md p-6" role="region" aria-labelledby="contact-heading">
+            <div className="card-premium p-6" role="region" aria-labelledby="contact-heading">
               <h3 className="text-lg font-bold text-gray-900 mb-4" id="contact-heading">
                 📋 Contact
               </h3>
@@ -499,7 +510,7 @@ export default function CandidateDetail() {
             </div>
 
             {/* Actions */}
-            <div className="bg-white rounded-lg shadow-md p-6" role="region" aria-labelledby="actions-heading">
+            <div className="card-premium p-6" role="region" aria-labelledby="actions-heading">
               <h3 className="text-lg font-bold text-gray-900 mb-4" id="actions-heading">
                 ⚡ Actions
               </h3>

--- a/frontend/src/app/candidates/page.tsx
+++ b/frontend/src/app/candidates/page.tsx
@@ -77,30 +77,30 @@ export default function CandidatesListPage() {
     <Layout>
       <div className="space-y-6">
         {/* Header */}
-        <div className="flex items-center justify-between">
+        <div className="flex flex-wrap items-center justify-between gap-3">
           <div>
-            <h1 className="text-2xl font-bold text-gray-900">Candidats</h1>
-            <p className="text-sm text-gray-500 mt-1">
+            <h1 className="font-display flex items-center gap-2.5 text-3xl font-extrabold text-gray-900">
+              <span className="flex h-9 w-9 items-center justify-center rounded-xl bg-gradient-to-br from-blue-500 to-indigo-500 text-white shadow-lg shadow-indigo-200/50"><Users className="h-5 w-5" /></span>
+              Candidats
+            </h1>
+            <p className="mt-1.5 text-sm text-gray-500">
               {filtered.length} candidat{filtered.length !== 1 ? 's' : ''} trouvé{filtered.length !== 1 ? 's' : ''}
             </p>
           </div>
-          <Link
-            href="/candidate/upload"
-            className="flex items-center gap-2 px-4 py-2.5 bg-indigo-600 text-white rounded-lg text-sm font-medium hover:bg-indigo-700 transition-colors"
-          >
+          <Link href="/candidate/upload" className="btn-primary !px-4 !py-2.5 text-sm">
             <Upload className="h-4 w-4" /> Uploader un CV
           </Link>
         </div>
 
         {/* Search */}
-        <div className="flex items-center gap-2 bg-white border border-gray-200 rounded-lg px-4 py-2.5 shadow-sm">
+        <div className="flex items-center gap-2 rounded-xl border border-gray-200 bg-white px-4 py-3 shadow-sm transition focus-within:border-indigo-400 focus-within:ring-2 focus-within:ring-indigo-100">
           <Search className="h-4 w-4 text-gray-400" />
           <input
             type="text"
             placeholder="Rechercher par nom, email ou poste..."
             value={search}
             onChange={(e) => setSearch(e.target.value)}
-            className="flex-1 text-sm outline-none bg-transparent"
+            className="flex-1 bg-transparent text-sm outline-none"
           />
           {search && (
             <button onClick={() => setSearch('')} className="text-gray-400 hover:text-gray-600">
@@ -132,21 +132,25 @@ export default function CandidatesListPage() {
             )}
           </div>
         ) : (
-          <div className="space-y-3">
+          <div className="grid gap-3 sm:grid-cols-2">
             {filtered.map((c) => (
               <div
                 key={c.id}
-                className="bg-white rounded-xl border border-gray-200 p-5 hover:shadow-md transition-shadow"
+                className="card-premium card-glow group p-5"
               >
                 <div className="flex items-start justify-between">
-                  <div className="min-w-0 flex-1">
+                  <div className="flex min-w-0 flex-1 items-start gap-3">
+                    <div className="flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-indigo-500 to-violet-500 text-base font-bold text-white">
+                      {(c.full_name || 'C')[0].toUpperCase()}
+                    </div>
+                    <div className="min-w-0">
                     <Link
                       href={`/candidates/${c.id}`}
-                      className="text-base font-semibold text-gray-900 hover:text-indigo-600 transition-colors"
+                      className="text-base font-bold text-gray-900 transition-colors hover:text-indigo-600"
                     >
                       {c.full_name}
                     </Link>
-                    <div className="flex flex-wrap items-center gap-3 mt-1.5 text-sm text-gray-500">
+                    <div className="mt-1.5 flex flex-wrap items-center gap-3 text-sm text-gray-500">
                       {c.email && (
                         <span className="flex items-center gap-1">
                           <Mail className="h-3.5 w-3.5" />{c.email}
@@ -163,15 +167,16 @@ export default function CandidatesListPage() {
                         </a>
                       )}
                     </div>
-                    {c.phone && <p className="text-xs text-gray-400 mt-1">{c.phone}</p>}
+                    {c.phone && <p className="mt-1 text-xs text-gray-400">{c.phone}</p>}
                     {c.is_fully_extracted && (
-                      <span className="inline-block mt-2 text-xs bg-green-100 text-green-700 px-2 py-0.5 rounded-full">
-                        Profil extrait
+                      <span className="mt-2 inline-flex items-center gap-1 rounded-full bg-emerald-100 px-2.5 py-0.5 text-xs font-semibold text-emerald-700">
+                        <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" /> Profil extrait
                       </span>
                     )}
+                    </div>
                   </div>
 
-                  <div className="flex items-center gap-2 flex-shrink-0 ml-4">
+                  <div className="ml-4 flex flex-shrink-0 items-center gap-2">
                     <button
                       onClick={() => toggleFavorite(c.id)}
                       className="p-1.5 rounded-full hover:bg-red-50 transition-colors"

--- a/frontend/src/app/demo/page.tsx
+++ b/frontend/src/app/demo/page.tsx
@@ -93,8 +93,8 @@ export default function DemoPage() {
       <div className="max-w-4xl mx-auto">
         {/* Header */}
         <div className="text-center mb-12">
-          <h1 className="text-4xl font-bold text-white mb-2">
-            🎯 AI Talent Finder — Phase 2 Demo
+          <h1 className="font-display text-4xl font-extrabold text-white mb-2 sm:text-5xl">
+            🎯 AI Talent Finder — <span className="gradient-text">Phase 2 Demo</span>
           </h1>
           <p className="text-gray-300 text-lg">
             Intelligent CV-Job Matching with LLM Explicability
@@ -159,7 +159,7 @@ export default function DemoPage() {
           <button
             onClick={handleGenerateExplanation}
             disabled={loading}
-            className="px-6 py-3 bg-blue-600 hover:bg-blue-700 text-white font-bold rounded-lg transition-all disabled:opacity-50"
+            className="btn-primary disabled:cursor-not-allowed disabled:opacity-50"
           >
             {loading ? '⏳ Generating Explanation...' : '📊 Get Match Explanation'}
           </button>
@@ -167,7 +167,7 @@ export default function DemoPage() {
           <button
             onClick={handleGenerateShortlistSummary}
             disabled={loading}
-            className="px-6 py-3 bg-indigo-600 hover:bg-indigo-700 text-white font-bold rounded-lg transition-all disabled:opacity-50"
+            className="btn-primary disabled:cursor-not-allowed disabled:opacity-50"
           >
             {loading ? '⏳ Generating Summary...' : '📈 Get Shortlist Summary'}
           </button>

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1,10 +1,12 @@
 @import "tailwindcss";
 
 /* ── LIGHT MODE TOKENS ───────────────────────────────────────── */
+/* Softer, less glaring light theme: muted cool-gray page background so
+   white cards gain depth and the UI is easier on the eyes than pure white. */
 :root {
-  --bg:#f9fafb; --bg-card:#fff; --bg-hover:#f3f4f6; --border:#e5e7eb;
+  --bg:#e7ebf1; --bg-card:#fff; --bg-hover:#dfe4ec; --border:#d5dbe6;
   --text-primary:#111827; --text-secondary:#374151; --text-muted:#9ca3af;
-  --input-bg:#fff; --input-border:#d1d5db; --input-text:#111827;
+  --input-bg:#fff; --input-border:#cbd2de; --input-text:#111827;
   --sidebar-bg:#fff; --sidebar-border:#e5e7eb;
   --sidebar-active-bg:#eef2ff; --sidebar-active-text:#4338ca;
   --sidebar-text:#4b5563; --sidebar-hover:#f3f4f6;
@@ -21,9 +23,151 @@ html.dark {
 }
 
 /* ── BASE ────────────────────────────────────────────────────── */
-body { background:var(--bg); color:var(--text-primary); font-family:Arial,Helvetica,sans-serif; }
+body {
+  background:var(--bg); color:var(--text-primary);
+  font-family:var(--font-sans),system-ui,-apple-system,"Segoe UI",Roboto,Arial,sans-serif;
+  -webkit-font-smoothing:antialiased; text-rendering:optimizeLegibility;
+}
 input,textarea,select { color:var(--input-text); background-color:var(--input-bg); border-color:var(--input-border); }
 input::placeholder,textarea::placeholder { color:var(--text-muted); }
+
+/* Display font for headings / hero typography */
+.font-display { font-family:var(--font-display),var(--font-sans),system-ui,sans-serif; letter-spacing:-0.02em; }
+
+/* ════════════════════════════════════════════════════════════════
+   PREMIUM DESIGN SYSTEM
+   Brand tokens + reusable component classes + animations.
+   Used across landing / auth (and rolled into the app).
+   ════════════════════════════════════════════════════════════════ */
+
+:root {
+  --brand:#6366f1;            /* indigo-500 */
+  --brand-strong:#4f46e5;     /* indigo-600 */
+  --brand-2:#8b5cf6;          /* violet-500 */
+  --brand-3:#06b6d4;          /* cyan-500   */
+  --ring:rgba(99,102,241,0.35);
+  --elev-1:0 1px 2px -1px rgba(31,41,86,0.18), 0 1px 3px rgba(31,41,86,0.10);
+  --elev-2:0 4px 12px -2px rgba(31,41,86,0.16), 0 2px 6px -2px rgba(31,41,86,0.10);
+  --elev-3:0 18px 40px -12px rgba(31,41,86,0.30), 0 8px 16px -8px rgba(31,41,86,0.16);
+  --grad-brand:linear-gradient(120deg,#6366f1 0%,#7c3aed 45%,#06b6d4 100%);
+}
+html.dark {
+  --ring:rgba(129,140,248,0.45);
+  --elev-1:0 1px 2px -1px rgba(0,0,0,0.5), 0 1px 3px rgba(0,0,0,0.4);
+  --elev-2:0 4px 12px -2px rgba(0,0,0,0.55), 0 2px 6px -2px rgba(0,0,0,0.4);
+  --elev-3:0 18px 40px -12px rgba(0,0,0,0.65), 0 8px 16px -8px rgba(0,0,0,0.5);
+}
+
+/* ── GRADIENT TEXT ───────────────────────────────────────────── */
+.gradient-text {
+  background:var(--grad-brand);
+  -webkit-background-clip:text; background-clip:text;
+  -webkit-text-fill-color:transparent; color:transparent;
+  background-size:200% 200%; animation:grad-pan 8s ease infinite;
+}
+
+/* ── BUTTONS ─────────────────────────────────────────────────── */
+.btn-primary {
+  position:relative; display:inline-flex; align-items:center; justify-content:center; gap:0.5rem;
+  border-radius:0.75rem; padding:0.7rem 1.4rem; font-weight:700; font-size:0.95rem;
+  color:#fff; background:var(--grad-brand); background-size:160% 160%;
+  box-shadow:0 8px 22px -8px rgba(99,102,241,0.65); border:1px solid rgba(255,255,255,0.12);
+  transition:transform .2s ease, box-shadow .25s ease, background-position .5s ease;
+}
+.btn-primary:hover { transform:translateY(-2px); box-shadow:0 14px 32px -8px rgba(99,102,241,0.75); background-position:100% 50%; }
+.btn-primary:active { transform:translateY(0); }
+
+.btn-ghost {
+  display:inline-flex; align-items:center; justify-content:center; gap:0.5rem;
+  border-radius:0.75rem; padding:0.7rem 1.3rem; font-weight:600; font-size:0.95rem;
+  color:var(--text-secondary); background:var(--bg-card);
+  border:1px solid var(--border); box-shadow:var(--elev-1);
+  transition:transform .2s ease, border-color .2s ease, background-color .2s ease;
+}
+.btn-ghost:hover { transform:translateY(-2px); border-color:var(--brand); }
+
+/* ── CARDS / SURFACES ────────────────────────────────────────── */
+.card-premium {
+  position:relative; border-radius:1.25rem; background:var(--bg-card);
+  border:1px solid var(--border); box-shadow:var(--elev-2);
+  transition:transform .3s cubic-bezier(.2,.7,.3,1), box-shadow .3s ease, border-color .3s ease;
+}
+.card-premium:hover { transform:translateY(-4px); box-shadow:var(--elev-3); border-color:var(--brand); }
+
+/* Gradient hairline border on hover (premium accent) */
+.card-glow { position:relative; }
+.card-glow::before {
+  content:""; position:absolute; inset:0; border-radius:inherit; padding:1px;
+  background:var(--grad-brand);
+  -webkit-mask:linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+  -webkit-mask-composite:xor; mask-composite:exclude;
+  opacity:0; transition:opacity .3s ease; pointer-events:none;
+}
+.card-glow:hover::before { opacity:1; }
+
+/* Glass panel */
+.glass-panel {
+  background:rgba(255,255,255,0.7); backdrop-filter:blur(16px) saturate(140%);
+  border:1px solid rgba(255,255,255,0.5); box-shadow:var(--elev-2);
+}
+html.dark .glass-panel { background:rgba(26,29,46,0.6); border-color:rgba(255,255,255,0.08); }
+
+/* ── BADGES / PILLS ──────────────────────────────────────────── */
+.pill {
+  display:inline-flex; align-items:center; gap:0.4rem;
+  border-radius:9999px; padding:0.35rem 0.85rem; font-size:0.8rem; font-weight:600;
+  background:rgba(99,102,241,0.1); color:var(--brand-strong); border:1px solid rgba(99,102,241,0.22);
+}
+html.dark .pill { color:#c7d2fe; background:rgba(99,102,241,0.16); border-color:rgba(99,102,241,0.3); }
+
+/* ── AURORA BACKGROUND (animated blurred orbs) ──────────────── */
+.aurora { position:absolute; inset:0; overflow:hidden; pointer-events:none; z-index:-10; }
+.aurora-orb { position:absolute; border-radius:9999px; filter:blur(80px); opacity:0.5; animation:float-orb 14s ease-in-out infinite; }
+html.dark .aurora-orb { opacity:0.32; }
+
+/* ── DIVIDER GRID ────────────────────────────────────────────── */
+.grid-overlay {
+  background-image:linear-gradient(to right, rgba(99,116,139,0.10) 1px, transparent 1px),
+    linear-gradient(to bottom, rgba(99,116,139,0.10) 1px, transparent 1px);
+  background-size:40px 40px;
+  mask-image:radial-gradient(ellipse at center, black 30%, transparent 78%);
+}
+html.dark .grid-overlay { background-image:linear-gradient(to right, rgba(148,163,184,0.07) 1px, transparent 1px),linear-gradient(to bottom, rgba(148,163,184,0.07) 1px, transparent 1px); }
+
+/* ── ANIMATIONS ──────────────────────────────────────────────── */
+@keyframes grad-pan { 0%,100%{background-position:0% 50%;} 50%{background-position:100% 50%;} }
+@keyframes float-orb { 0%,100%{transform:translate(0,0) scale(1);} 33%{transform:translate(30px,-24px) scale(1.08);} 66%{transform:translate(-22px,18px) scale(0.95);} }
+@keyframes fade-up { from{opacity:0; transform:translateY(18px);} to{opacity:1; transform:translateY(0);} }
+@keyframes fade-in { from{opacity:0;} to{opacity:1;} }
+@keyframes pop-in { from{opacity:0; transform:translateY(14px) scale(.97);} to{opacity:1; transform:translateY(0) scale(1);} }
+@keyframes shimmer { 0%{background-position:-200% 0;} 100%{background-position:200% 0;} }
+
+.anim-fade-up { opacity:0; animation:fade-up .7s cubic-bezier(.2,.7,.3,1) forwards; }
+.anim-pop { opacity:0; animation:pop-in .8s cubic-bezier(.2,.7,.3,1) forwards; }
+.anim-fade-in { opacity:0; animation:fade-in .9s ease forwards; }
+.delay-1{animation-delay:.08s;} .delay-2{animation-delay:.16s;} .delay-3{animation-delay:.24s;}
+.delay-4{animation-delay:.32s;} .delay-5{animation-delay:.4s;} .delay-6{animation-delay:.48s;}
+
+@media (prefers-reduced-motion: reduce) {
+  .gradient-text,.aurora-orb,.anim-fade-up,.anim-pop,.anim-fade-in,.btn-primary { animation:none!important; }
+  .anim-fade-up,.anim-pop,.anim-fade-in { opacity:1; }
+}
+
+/* ── GLASS NAV (public pages: landing / login / register) ────── */
+/* Own class so the translucent navbar themes reliably in both modes,
+   instead of depending on overrides of Tailwind's bg-white/xx opacity
+   utilities (which don't match cleanly). */
+.glass-nav { background-color:rgba(255,255,255,0.85); }
+html.dark .glass-nav { background-color:rgba(20,23,37,0.88); }
+
+/* ── LIGHT MODE SURFACE TONING ───────────────────────────────── */
+/* Page-level backgrounds (gray-50/slate-50) get the muted page tone so the
+   app no longer reads as a glaring white sheet. White cards stay white and
+   pop with depth. Dark-mode rules below (html.dark) override these. */
+html:not(.dark) .bg-gray-50,
+html:not(.dark) .bg-slate-50  { background-color:var(--bg); }
+html:not(.dark) .bg-gray-100,
+html:not(.dark) .bg-slate-100 { background-color:var(--bg-hover); }
 
 /* ── DARK MODE OVERRIDES ─────────────────────────────────────── */
 
@@ -31,6 +175,7 @@ input::placeholder,textarea::placeholder { color:var(--text-muted); }
 html.dark .bg-white            { background-color:var(--bg-card)!important; }
 html.dark .bg-gray-50          { background-color:var(--bg)!important; }
 html.dark .bg-gray-100         { background-color:var(--bg-hover)!important; }
+html.dark .bg-gray-200         { background-color:#2d3348!important; }
 html.dark .border-gray-200,
 html.dark .border-gray-300     { border-color:var(--border)!important; }
 html.dark .text-gray-900,
@@ -116,6 +261,21 @@ html.dark .text-purple-600     { color:#c084fc!important; }
 html.dark .border-purple-200   { border-color:rgba(168,85,247,0.3)!important; }
 html.dark .from-purple-50      { --tw-gradient-from:rgba(168,85,247,0.1)!important; }
 html.dark .to-pink-50          { --tw-gradient-to:rgba(236,72,153,0.1)!important; }
+
+/* --- VIOLET --------------------------------------------------- */
+html.dark .bg-violet-50         { background-color:rgba(139,92,246,0.1)!important; }
+html.dark .bg-violet-100        { background-color:rgba(139,92,246,0.16)!important; }
+html.dark .text-violet-600,
+html.dark .text-violet-700      { color:#c4b5fd!important; }
+html.dark .text-violet-900      { color:#ddd6fe!important; }
+html.dark .border-violet-200    { border-color:rgba(139,92,246,0.3)!important; }
+html.dark .border-violet-600    { border-color:rgba(139,92,246,0.6)!important; }
+html.dark .hover\:border-violet-300:hover { border-color:rgba(139,92,246,0.45)!important; }
+
+/* --- CYAN extras --------------------------------------------- */
+html.dark .text-cyan-600        { color:#67e8f9!important; }
+html.dark .text-cyan-900        { color:#a5f3fc!important; }
+html.dark .border-cyan-500      { border-color:rgba(6,182,212,0.6)!important; }
 
 /* --- RED ----------------------------------------------------- */
 html.dark .bg-red-50           { background-color:rgba(239,68,68,0.08)!important; }

--- a/frontend/src/app/jobs/page.tsx
+++ b/frontend/src/app/jobs/page.tsx
@@ -85,19 +85,19 @@ export default function JobsPage() {
       <div>
         <div className="mb-8 flex items-center justify-between gap-4">
           <div>
-            <h1 className="text-3xl font-bold text-gray-900">Gestion des critères</h1>
-            <p className="text-gray-600 mt-2">
+            <h1 className="font-display text-3xl font-extrabold text-gray-900">Gestion des critères</h1>
+            <p className="mt-2 text-gray-600">
               Créez, éditez et consultez vos critères de matching pour les candidats.
             </p>
           </div>
-          <Link href="/matching" className="px-5 py-3 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700">
+          <Link href="/matching" className="btn-primary !px-5 !py-3">
             Aller au matching
           </Link>
         </div>
 
         <div className="grid lg:grid-cols-2 gap-6">
-          <section className="bg-white rounded-xl border border-gray-200 p-6 shadow-sm">
-            <h2 className="text-xl font-semibold text-gray-900 mb-4">Créer un nouveau critère</h2>
+          <section className="card-premium p-6">
+            <h2 className="font-display text-xl font-bold text-gray-900 mb-4">Créer un nouveau critère</h2>
 
             <div className="space-y-4">
               <div>
@@ -186,16 +186,16 @@ export default function JobsPage() {
               <button
                 onClick={handleSubmit}
                 disabled={submitting}
-                className="w-full rounded-lg bg-indigo-600 px-4 py-3 text-white hover:bg-indigo-700 disabled:opacity-60"
+                className="btn-primary w-full disabled:cursor-not-allowed disabled:opacity-60"
               >
                 {submitting ? 'Création en cours...' : 'Créer le critère'}
               </button>
             </div>
           </section>
 
-          <section className="bg-white rounded-xl border border-gray-200 p-6 shadow-sm">
+          <section className="card-premium p-6">
             <div className="flex items-center justify-between mb-4">
-              <h2 className="text-xl font-semibold text-gray-900">Liste des critères</h2>
+              <h2 className="font-display text-xl font-bold text-gray-900">Liste des critères</h2>
               <span className="text-sm text-gray-500">{criteriaList?.length ?? 0} critères</span>
             </div>
 

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,13 +1,28 @@
 import type { Metadata } from "next";
 import Script from "next/script";
+import { Inter, Plus_Jakarta_Sans } from "next/font/google";
 import Providers from "@/components/Providers";
 import "./globals.css";
+
+// Body copy: Inter — clean, highly legible. Headings: Plus Jakarta Sans —
+// geometric, modern, premium. Exposed as CSS variables consumed in globals.css.
+const inter = Inter({
+  subsets: ["latin"],
+  variable: "--font-sans",
+  display: "swap",
+});
+const jakarta = Plus_Jakarta_Sans({
+  subsets: ["latin"],
+  weight: ["500", "600", "700", "800"],
+  variable: "--font-display",
+  display: "swap",
+});
 
 // FORCE BUILD: 2025-05-10T00:55 UTC - Production deploy with API trailing slash fixes
 export const metadata: Metadata = { title:"AI Talent Finder", description:"Plateforme intelligente de recrutement — ESISA TechForge4" };
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="fr" className="h-full antialiased">
+    <html lang="fr" className={`h-full antialiased ${inter.variable} ${jakarta.variable}`}>
       <head>
         <Script src="/runtime-config.js" strategy="beforeInteractive" />
       </head>

--- a/frontend/src/app/matching/page.tsx
+++ b/frontend/src/app/matching/page.tsx
@@ -204,7 +204,7 @@ export default function MatchingPage() {
                 Matching personnalisable
               </div>
               <div>
-                <h1 className="text-3xl font-semibold tracking-tight md:text-5xl">
+                <h1 className="font-display text-3xl font-extrabold tracking-tight md:text-5xl">
                   Construisez vos critères, puis lancez le classement instantané.
                 </h1>
                 <p className="mt-3 max-w-2xl text-sm text-slate-200 md:text-base">
@@ -235,7 +235,7 @@ export default function MatchingPage() {
           <section className="space-y-6 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
             <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
               <div>
-                <h2 className="text-xl font-semibold text-slate-900">Matrice de critères</h2>
+                <h2 className="font-display text-xl font-bold text-slate-900">Matrice de critères</h2>
                 <p className="text-sm text-slate-500">Compétences et poids du recruteur.</p>
               </div>
               <div className="flex items-center gap-2">
@@ -361,7 +361,7 @@ export default function MatchingPage() {
                     type="button"
                     onClick={() => launchRankAll()}
                     disabled={rankAllLoading || !selectedCriteriaId}
-                    className="inline-flex items-center gap-2 rounded-2xl bg-sky-600 px-4 py-3 text-sm font-semibold text-white transition hover:bg-sky-500 disabled:cursor-not-allowed disabled:opacity-60"
+                    className="btn-primary !rounded-2xl disabled:cursor-not-allowed disabled:opacity-60"
                   >
                     <Play className="h-4 w-4" />
                     {rankAllLoading ? "Classement en cours..." : "Lancer le classement"}
@@ -375,7 +375,7 @@ export default function MatchingPage() {
           <section className="space-y-6 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
             <div className="flex items-start justify-between gap-4">
               <div>
-                <h2 className="text-xl font-semibold text-slate-900">Répartition des poids</h2>
+                <h2 className="font-display text-xl font-bold text-slate-900">Répartition des poids</h2>
                 <p className="text-sm text-slate-500">Distribution en temps réel.</p>
               </div>
               <div className="rounded-2xl bg-slate-50 px-3 py-2 text-sm text-slate-600">
@@ -490,7 +490,7 @@ export default function MatchingPage() {
         <section className="space-y-5 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
           <div className="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
             <div>
-              <h2 className="text-xl font-semibold text-slate-900">Classement de mes candidats</h2>
+              <h2 className="font-display text-xl font-bold text-slate-900">Classement de mes candidats</h2>
               <p className="text-sm text-slate-500">
                 Tous vos candidats classés du meilleur score au plus faible, basé sur les compétences
                 extraites de leur CV.

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -3,25 +3,22 @@
 import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { Manrope } from 'next/font/google';
 import {
   ArrowRight,
   Briefcase,
   CheckCircle2,
   Cpu,
+  Gauge,
   Lock,
   MessageSquare,
-  ShieldCheck,
+  Quote,
+  Search,
   Sparkles,
   Target,
   Users,
   Zap,
 } from 'lucide-react';
-
-const manrope = Manrope({
-  subsets: ['latin'],
-  weight: ['500', '600', '700', '800'],
-});
+import ThemeToggle from '@/components/ThemeToggle';
 
 export default function Home() {
   const router = useRouter();
@@ -32,7 +29,7 @@ export default function Home() {
 
   useEffect(() => {
     const token = localStorage.getItem('access_token');
-    
+
     if (token) {
       const role = localStorage.getItem('user_role');
       if (role === 'admin') {
@@ -51,11 +48,13 @@ export default function Home() {
 
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
-        <div className="text-center">
-          <div className="animate-pulse space-y-4">
-            <div className="h-12 bg-gray-200 rounded w-64 mx-auto"></div>
-            <div className="h-6 bg-gray-200 rounded w-48 mx-auto"></div>
+      <div className="flex min-h-screen items-center justify-center bg-slate-50">
+        <div className="flex flex-col items-center gap-4">
+          <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-blue-600 to-indigo-600 text-white shadow-lg shadow-indigo-300/50">
+            <Sparkles className="h-6 w-6 animate-pulse" />
+          </div>
+          <div className="h-1.5 w-40 overflow-hidden rounded-full bg-slate-200">
+            <div className="h-full w-1/2 animate-[shimmer_1.2s_infinite] bg-gradient-to-r from-transparent via-indigo-500 to-transparent bg-[length:200%_100%]" />
           </div>
         </div>
       </div>
@@ -67,58 +66,58 @@ export default function Home() {
       icon: <Cpu className="h-6 w-6" />,
       title: 'Matching IA contextuel',
       text: 'Analyse sémantique CV-offre avec scoring explicable pour accélérer les décisions.',
-      accent: 'border-l-4 border-blue-500',
       iconBg: 'bg-blue-100 text-blue-700',
     },
     {
       icon: <Zap className="h-6 w-6" />,
       title: 'Pipeline ultra rapide',
       text: 'Du dépôt CV à la shortlist en quelques secondes, avec résultats actionnables.',
-      accent: 'border-l-4 border-purple-500',
-      iconBg: 'bg-purple-100 text-purple-700',
+      iconBg: 'bg-violet-100 text-violet-700',
     },
     {
       icon: <Target className="h-6 w-6" />,
       title: 'Décisions plus précises',
       text: 'Réduction du bruit via normalisation, déduplication et pondération métier.',
-      accent: 'border-l-4 border-cyan-500',
       iconBg: 'bg-cyan-100 text-cyan-700',
     },
     {
       icon: <Briefcase className="h-6 w-6" />,
       title: 'Expérience recruteur',
       text: 'Mode recherche, génération de profil idéal, shortlist et export en continu.',
-      accent: 'border-l-4 border-emerald-500',
       iconBg: 'bg-emerald-100 text-emerald-700',
     },
     {
       icon: <Users className="h-6 w-6" />,
       title: 'Expérience candidat',
       text: 'Profil structuré, extraction automatique et visibilité sur les opportunités.',
-      accent: 'border-l-4 border-orange-500',
       iconBg: 'bg-orange-100 text-orange-700',
     },
     {
       icon: <Lock className="h-6 w-6" />,
       title: 'Sécurité & conformité',
       text: 'Authentification JWT, bonnes pratiques RGPD et contrôle du cycle de données.',
-      accent: 'border-l-4 border-slate-500',
       iconBg: 'bg-slate-100 text-slate-700',
     },
+  ];
+
+  const steps = [
+    { icon: <Briefcase className="h-5 w-5" />, title: 'Définissez le besoin', text: 'Décrivez le poste ou laissez l’IA générer le profil idéal à partir de critères métier.' },
+    { icon: <Search className="h-5 w-5" />, title: 'Lancez le matching', text: 'Le moteur sémantique compare CV et offre, puis classe les profils par pertinence.' },
+    { icon: <CheckCircle2 className="h-5 w-5" />, title: 'Décidez & shortlistez', text: 'Scores explicables, raisons claires, export — du candidat brut à la décision RH.' },
   ];
 
   const faqs = [
     {
       q: 'Comment fonctionne le matching par IA ?',
-      a: "Nous combinons extraction NLP, embeddings sémantiques et scoring métier pour prioriser les profils les plus pertinents.",
+      a: 'Nous combinons extraction NLP, embeddings sémantiques et scoring métier pour prioriser les profils les plus pertinents.',
     },
     {
       q: 'Puis-je utiliser la plateforme pour des profils rares ?',
-      a: "Oui. Le mode génération IA permet de décrire un besoin complexe, puis de rechercher les candidats les plus proches du profil cible.",
+      a: 'Oui. Le mode génération IA permet de décrire un besoin complexe, puis de rechercher les candidats les plus proches du profil cible.',
     },
     {
       q: 'Mes données candidats sont-elles protégées ?',
-      a: "Oui. Authentification JWT, isolation des accès et bonnes pratiques de stockage sont appliquées côté plateforme.",
+      a: 'Oui. Authentification JWT, isolation des accès et bonnes pratiques de stockage sont appliquées côté plateforme.',
     },
     {
       q: 'Combien de temps pour obtenir une shortlist ?',
@@ -127,222 +126,286 @@ export default function Home() {
   ];
 
   return (
-    <div className={`${manrope.className} relative min-h-screen overflow-x-hidden bg-slate-50 text-slate-900`}>
-      <div className="pointer-events-none absolute inset-0 -z-10">
-        <div className="absolute -top-24 -left-20 h-72 w-72 rounded-full bg-blue-300/30 blur-3xl" />
-        <div className="absolute top-40 -right-20 h-72 w-72 rounded-full bg-indigo-300/30 blur-3xl" />
-        <div className="absolute bottom-0 left-1/3 h-96 w-96 rounded-full bg-cyan-200/25 blur-3xl" />
-        <div className="hero-grid absolute inset-0 opacity-30" />
+    <div className="relative min-h-screen overflow-x-hidden bg-slate-50 text-slate-900">
+      {/* Aurora background */}
+      <div className="aurora">
+        <div className="aurora-orb left-[-8%] top-[-6%] h-80 w-80 bg-blue-400" />
+        <div className="aurora-orb right-[-6%] top-[18%] h-96 w-96 bg-violet-400" style={{ animationDelay: '-4s' }} />
+        <div className="aurora-orb bottom-[6%] left-[28%] h-[26rem] w-[26rem] bg-cyan-300" style={{ animationDelay: '-8s' }} />
+        <div className="grid-overlay absolute inset-0 opacity-60" />
       </div>
 
-      <nav className="sticky top-0 z-50 border-b border-slate-200/70 bg-white/75 backdrop-blur-xl">
-        <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-4 sm:px-6 lg:px-8">
+      {/* NAV */}
+      <nav className="glass-nav sticky top-0 z-50 border-b border-slate-200 shadow-sm shadow-slate-200/50 backdrop-blur-xl">
+        <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-3.5 sm:px-6 lg:px-8">
           <div className="flex items-center gap-3">
-            <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-gradient-to-br from-blue-600 to-indigo-600 text-white shadow-lg shadow-blue-200">
+            <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-gradient-to-br from-blue-600 to-indigo-600 text-white shadow-lg shadow-indigo-300/50">
               <Sparkles className="h-5 w-5" />
             </div>
             <div>
-              <p className="text-sm font-semibold text-slate-500">AI Recruiting Platform</p>
-              <p className="text-lg font-bold">AI Talent Finder</p>
+              <p className="text-[0.7rem] font-bold uppercase tracking-[0.18em] text-indigo-600">AI Recruiting Platform</p>
+              <p className="font-display text-lg font-bold leading-none text-slate-900">AI Talent Finder</p>
             </div>
           </div>
 
-          <div className="hidden items-center gap-5 md:flex">
-            <Link href="#about" className="text-sm font-semibold text-slate-600 transition hover:text-slate-900">À propos</Link>
-            <Link href="#faq" className="text-sm font-semibold text-slate-600 transition hover:text-slate-900">FAQ</Link>
-            <Link href="#contact" className="text-sm font-semibold text-slate-600 transition hover:text-slate-900">Contact</Link>
+          <div className="hidden items-center gap-7 md:flex">
+            <Link href="#about" className="text-sm font-semibold text-slate-700 transition hover:text-indigo-600">À propos</Link>
+            <Link href="#how" className="text-sm font-semibold text-slate-700 transition hover:text-indigo-600">Comment ça marche</Link>
+            <Link href="#faq" className="text-sm font-semibold text-slate-700 transition hover:text-indigo-600">FAQ</Link>
+            <Link href="#contact" className="text-sm font-semibold text-slate-700 transition hover:text-indigo-600">Contact</Link>
           </div>
 
           <div className="flex items-center gap-2 sm:gap-3">
-            <Link href="/auth/login" className="rounded-lg px-3 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-100 sm:px-4">
+            <ThemeToggle />
+            <Link href="/auth/login" className="rounded-lg px-3 py-2 text-sm font-semibold text-slate-800 transition hover:bg-slate-100 sm:px-4">
               Connexion
             </Link>
-            <Link
-              href="/auth/register"
-              className="rounded-lg bg-gradient-to-r from-blue-600 to-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-md transition hover:from-blue-700 hover:to-indigo-700 sm:px-4"
-            >
+            <Link href="/auth/register" className="btn-primary !px-4 !py-2 text-sm">
               Inscription
             </Link>
           </div>
         </div>
       </nav>
 
-      <section className="mx-auto grid max-w-7xl gap-8 px-4 pb-12 pt-10 sm:gap-10 sm:px-6 sm:pb-16 sm:pt-14 lg:grid-cols-2 lg:items-center lg:px-8">
-        <div className="space-y-8 animate-slide-up">
-          <span className="inline-flex items-center gap-2 rounded-full border border-blue-200 bg-blue-50 px-4 py-2 text-sm font-semibold text-blue-700">
-            <CheckCircle2 className="h-4 w-4" />
+      {/* HERO */}
+      <section className="mx-auto grid max-w-7xl gap-10 px-4 pb-16 pt-12 sm:px-6 lg:grid-cols-2 lg:items-center lg:px-8 lg:pt-20">
+        <div className="space-y-8">
+          <span className="pill anim-fade-up">
+            <span className="relative flex h-2 w-2">
+              <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-400 opacity-75" />
+              <span className="relative inline-flex h-2 w-2 rounded-full bg-emerald-500" />
+            </span>
             Plateforme de matching IA prête pour la prod
           </span>
 
-          <div className="space-y-4">
-            <h1 className="text-4xl font-extrabold leading-tight text-slate-900 sm:text-5xl lg:text-6xl">
-              Le recrutement intelligent
-              <span className="block bg-gradient-to-r from-blue-600 to-indigo-600 bg-clip-text text-transparent">
-                qui fait gagner du temps
-              </span>
+          <div className="space-y-5">
+            <h1 className="font-display anim-fade-up delay-1 text-5xl font-extrabold leading-[1.05] text-slate-900 sm:text-6xl lg:text-7xl">
+              Le recrutement
+              <span className="block gradient-text">intelligent</span>
+              qui fait gagner du temps
             </h1>
-            <p className="max-w-xl text-lg text-slate-600 sm:text-xl">
-              Unifiez l'expérience recruteur et candidat avec un matching sémantique puissant,
-              des scores lisibles et un parcours fluide de l'import CV à la shortlist.
+            <p className="anim-fade-up delay-2 max-w-xl text-lg text-slate-600 sm:text-xl">
+              Unifiez l’expérience recruteur et candidat avec un matching sémantique puissant,
+              des scores lisibles et un parcours fluide de l’import CV à la shortlist.
             </p>
-
-            <div className="inline-flex items-center rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs font-semibold text-slate-600 shadow-sm sm:text-sm">
-              Adopte par des equipes RH tech, conseil et retail en phase de pre-production.
-            </div>
           </div>
 
-          <div className="flex flex-wrap gap-3">
-            <Link
-              href="/auth/register?role=recruiter"
-              className="group inline-flex items-center gap-2 rounded-xl bg-gradient-to-r from-blue-600 to-indigo-600 px-6 py-3 font-semibold text-white shadow-lg shadow-blue-200 transition hover:translate-y-[-1px] hover:from-blue-700 hover:to-indigo-700"
-            >
-              Demarrer cote recruteur
-              <ArrowRight className="h-4 w-4 transition group-hover:translate-x-0.5" />
+          <div className="anim-fade-up delay-3 flex flex-wrap gap-3">
+            <Link href="/auth/register?role=recruiter" className="btn-primary group">
+              Démarrer côté recruteur
+              <ArrowRight className="h-4 w-4 transition group-hover:translate-x-1" />
             </Link>
-            <Link
-              href="/auth/register?role=candidate"
-              className="group inline-flex items-center gap-2 rounded-xl border border-slate-300 bg-white px-6 py-3 font-semibold text-slate-700 shadow-sm transition hover:border-slate-400 hover:bg-slate-100"
-            >
-              Creer mon profil candidat
-              <ArrowRight className="h-4 w-4 transition group-hover:translate-x-0.5" />
+            <Link href="/auth/register?role=candidate" className="btn-ghost group">
+              Créer mon profil candidat
+              <ArrowRight className="h-4 w-4 transition group-hover:translate-x-1" />
             </Link>
           </div>
 
-          <div className="grid grid-cols-3 gap-3 text-center sm:gap-4">
-            <div className="rounded-xl border border-slate-200 bg-white p-3 shadow-sm">
-              <p className="text-2xl font-extrabold text-blue-600">92%</p>
-              <p className="text-xs font-semibold text-slate-500">Précision NLP</p>
-            </div>
-            <div className="rounded-xl border border-slate-200 bg-white p-3 shadow-sm">
-              <p className="text-2xl font-extrabold text-indigo-600">&lt;2s</p>
-              <p className="text-xs font-semibold text-slate-500">Réponse moyenne</p>
-            </div>
-            <div className="rounded-xl border border-slate-200 bg-white p-3 shadow-sm">
-              <p className="text-2xl font-extrabold text-cyan-600">27+</p>
-              <p className="text-xs font-semibold text-slate-500">Routes API</p>
-            </div>
+          <div className="anim-fade-up delay-4 grid grid-cols-3 gap-3 sm:gap-4">
+            {[
+              { v: '92%', l: 'Précision NLP', c: 'text-blue-600' },
+              { v: '<2s', l: 'Réponse moyenne', c: 'text-violet-600' },
+              { v: '27+', l: 'Routes API', c: 'text-cyan-600' },
+            ].map((s) => (
+              <div key={s.l} className="card-premium px-3 py-4 text-center">
+                <p className={`font-display text-2xl font-extrabold sm:text-3xl ${s.c}`}>{s.v}</p>
+                <p className="mt-1 text-xs font-semibold text-slate-500">{s.l}</p>
+              </div>
+            ))}
           </div>
         </div>
 
-        <div className="relative animate-float">
-          <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-2xl shadow-slate-200 sm:p-8">
-            <div className="mb-6 flex items-center justify-between">
-              <h2 className="text-lg font-bold text-slate-900">Tableau de pilotage IA</h2>
-              <span className="rounded-full bg-emerald-100 px-3 py-1 text-xs font-semibold text-emerald-700">Live</span>
+        {/* Floating glass dashboard mockup */}
+        <div className="anim-pop delay-2 relative">
+          <div className="absolute -inset-4 -z-10 rounded-[2rem] bg-gradient-to-tr from-blue-500/20 via-violet-500/20 to-cyan-400/20 blur-2xl" />
+          <div className="card-premium card-glow overflow-hidden p-6 sm:p-7">
+            <div className="mb-5 flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <Gauge className="h-5 w-5 text-indigo-600" />
+                <h2 className="font-display text-lg font-bold text-slate-900">Tableau de pilotage IA</h2>
+              </div>
+              <span className="inline-flex items-center gap-1.5 rounded-full bg-emerald-100 px-2.5 py-1 text-xs font-bold text-emerald-700">
+                <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" /> Live
+              </span>
             </div>
 
-            <div className="space-y-4">
-              <div className="rounded-xl border-l-4 border-blue-500 bg-slate-50 p-4 transition hover:bg-blue-50/50">
-                <p className="text-sm font-semibold text-slate-500">Matching sur base existante</p>
-                <p className="mt-1 text-lg font-bold text-slate-900">+143 profils recommandés</p>
-              </div>
-              <div className="rounded-xl border-l-4 border-purple-500 bg-slate-50 p-4 transition hover:bg-purple-50/50">
-                <p className="text-sm font-semibold text-slate-500">Profil généré par IA</p>
-                <p className="mt-1 text-lg font-bold text-slate-900">Senior Data Engineer MLOps</p>
-              </div>
-              <div className="rounded-xl border-l-4 border-emerald-500 bg-slate-50 p-4 transition hover:bg-emerald-50/50">
-                <p className="text-sm font-semibold text-slate-500">Actions shortlist cette semaine</p>
-                <p className="mt-1 text-lg font-bold text-slate-900">38 candidats validés</p>
-              </div>
+            <div className="space-y-3">
+              {[
+                { c: 'from-blue-500 to-indigo-500', t: 'Matching sur base existante', v: '+143 profils recommandés', w: 'w-[88%]' },
+                { c: 'from-violet-500 to-fuchsia-500', t: 'Profil généré par IA', v: 'Senior Data Engineer MLOps', w: 'w-[72%]' },
+                { c: 'from-emerald-500 to-teal-500', t: 'Actions shortlist cette semaine', v: '38 candidats validés', w: 'w-[64%]' },
+              ].map((row) => (
+                <div key={row.t} className="rounded-xl border border-slate-200 bg-slate-50 p-4 transition hover:border-indigo-200 hover:bg-white">
+                  <div className="flex items-center justify-between">
+                    <p className="text-xs font-semibold text-slate-500">{row.t}</p>
+                    <span className={`h-2 w-2 rounded-full bg-gradient-to-r ${row.c}`} />
+                  </div>
+                  <p className="mt-1 font-display text-base font-bold text-slate-900">{row.v}</p>
+                  <div className="mt-2.5 h-1.5 w-full overflow-hidden rounded-full bg-slate-200">
+                    <div className={`h-full ${row.w} rounded-full bg-gradient-to-r ${row.c}`} />
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            <div className="mt-5 flex items-center gap-3 rounded-xl bg-gradient-to-r from-indigo-600 to-violet-600 p-4 text-white">
+              <Sparkles className="h-5 w-5 flex-shrink-0" />
+              <p className="text-sm font-semibold">Score moyen de matching en hausse de 18% ce mois-ci.</p>
             </div>
           </div>
         </div>
       </section>
 
-      <section id="about" className="mx-auto max-w-7xl px-4 py-10 sm:px-6 sm:py-12 lg:px-8">
-        <div className="grid gap-6 rounded-3xl border border-slate-200 bg-white p-8 shadow-lg shadow-slate-100 md:grid-cols-2">
+      {/* LOGOS / TRUST STRIP */}
+      <section className="mx-auto max-w-7xl px-4 pb-6 sm:px-6 lg:px-8">
+        <p className="mb-5 text-center text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">
+          Adoptée par des équipes RH tech, conseil et retail en pré-production
+        </p>
+        <div className="flex flex-wrap items-center justify-center gap-x-10 gap-y-4 opacity-70">
+          {['NeuroHR', 'TalentFlow', 'RecruitX', 'HirePilot', 'CoreTeam'].map((b) => (
+            <span key={b} className="font-display text-lg font-bold tracking-tight text-slate-400">{b}</span>
+          ))}
+        </div>
+      </section>
+
+      {/* ABOUT */}
+      <section id="about" className="mx-auto max-w-7xl px-4 py-14 sm:px-6 lg:px-8">
+        <div className="card-premium grid gap-8 p-8 md:grid-cols-2 md:p-10">
           <div>
-            <p className="mb-2 text-sm font-bold uppercase tracking-widest text-indigo-600">À propos</p>
-            <h3 className="text-3xl font-extrabold text-slate-900">Un moteur de recrutement orienté décision</h3>
+            <p className="pill mb-4">À propos</p>
+            <h3 className="font-display text-3xl font-extrabold text-slate-900 sm:text-4xl">
+              Un moteur de recrutement <span className="gradient-text">orienté décision</span>
+            </h3>
             <p className="mt-4 text-slate-600">
               AI Talent Finder combine NLP, engineering de features et règles métier pour produire
               des recommandations lisibles, rapides et utiles aux équipes RH.
             </p>
           </div>
           <div className="space-y-3">
-            <div className="rounded-xl border-l-4 border-blue-500 bg-blue-50 p-4 text-blue-900">
-              Extraction des compétences, postes et signaux clés depuis les CV.
-            </div>
-            <div className="rounded-xl border-l-4 border-purple-500 bg-purple-50 p-4 text-purple-900">
-              Scoring explicable avec logique accepted / to_review / rejected.
-            </div>
-            <div className="rounded-xl border-l-4 border-cyan-500 bg-cyan-50 p-4 text-cyan-900">
-              Expérience alignée entre interface recruteur et espace candidat.
-            </div>
-          </div>
-        </div>
-      </section>
-
-      <section className="mx-auto max-w-7xl px-4 py-10 sm:px-6 sm:py-14 lg:px-8">
-        <div className="mb-8 flex items-end justify-between">
-          <div>
-            <p className="text-sm font-bold uppercase tracking-widest text-blue-600">Pourquoi nous</p>
-            <h3 className="text-3xl font-extrabold text-slate-900">Un rendu pro, des résultats concrets</h3>
-          </div>
-        </div>
-        <div className="grid gap-5 md:grid-cols-2 xl:grid-cols-3">
-          {features.map((feature, index) => (
-            <article
-              key={feature.title}
-              className={`group animate-rise rounded-2xl bg-white p-6 shadow-md transition duration-300 hover:-translate-y-1 hover:shadow-xl ${feature.accent}`}
-              style={{ animationDelay: `${index * 80}ms` }}
-            >
-              <div className={`mb-4 inline-flex rounded-lg p-3 ${feature.iconBg}`}>{feature.icon}</div>
-              <h4 className="text-xl font-bold text-slate-900">{feature.title}</h4>
-              <p className="mt-2 text-slate-600">{feature.text}</p>
-            </article>
-          ))}
-        </div>
-      </section>
-
-      <section id="faq" className="mx-auto max-w-7xl px-4 py-10 sm:px-6 sm:py-14 lg:px-8">
-        <div className="rounded-3xl bg-gradient-to-r from-slate-900 to-indigo-950 p-8 text-white shadow-2xl md:p-10">
-          <div className="mb-8 flex items-center gap-3">
-            <MessageSquare className="h-6 w-6 text-cyan-300" />
-            <h3 className="text-3xl font-extrabold">FAQ</h3>
-          </div>
-
-            <div className="space-y-3">
-            {faqs.map((item, idx) => (
-              <div key={item.q} className="rounded-xl border border-white/20 bg-white/10 p-4 transition hover:bg-white/15">
-                <button
-                  onClick={() => setFaqOpen(faqOpen === idx ? null : idx)}
-                  className="flex w-full items-center justify-between text-left"
-                >
-                  <span className="pr-4 text-base font-semibold md:text-lg">{item.q}</span>
-                  <span className="text-xl leading-none">{faqOpen === idx ? '−' : '+'}</span>
-                </button>
-                {faqOpen === idx && <p className="mt-3 text-sm text-slate-100 md:text-base">{item.a}</p>}
-              </div>
+            {[
+              { c: 'border-blue-500 bg-blue-50 text-blue-900', t: 'Extraction des compétences, postes et signaux clés depuis les CV.' },
+              { c: 'border-violet-500 bg-violet-50 text-violet-900', t: 'Scoring explicable avec logique accepted / to_review / rejected.' },
+              { c: 'border-cyan-500 bg-cyan-50 text-cyan-900', t: 'Expérience alignée entre interface recruteur et espace candidat.' },
+            ].map((x) => (
+              <div key={x.t} className={`rounded-xl border-l-4 p-4 text-sm font-medium ${x.c}`}>{x.t}</div>
             ))}
           </div>
         </div>
       </section>
 
-      <section id="contact" className="mx-auto max-w-7xl px-4 py-10 sm:px-6 sm:py-14 lg:px-8">
-        <div className="grid gap-6 rounded-3xl border border-slate-200 bg-white p-8 shadow-lg shadow-slate-100 lg:grid-cols-2">
+      {/* FEATURES */}
+      <section className="mx-auto max-w-7xl px-4 py-14 sm:px-6 lg:px-8">
+        <div className="mb-10 text-center">
+          <p className="pill mx-auto mb-3">Pourquoi nous</p>
+          <h3 className="font-display text-3xl font-extrabold text-slate-900 sm:text-4xl">Un rendu pro, des résultats concrets</h3>
+          <p className="mx-auto mt-3 max-w-2xl text-slate-600">Tout ce qu’il faut pour passer du CV brut à une décision de recrutement étayée.</p>
+        </div>
+        <div className="grid gap-5 md:grid-cols-2 xl:grid-cols-3">
+          {features.map((feature, index) => (
+            <article
+              key={feature.title}
+              className={`card-premium card-glow group anim-fade-up p-6 delay-${(index % 6) + 1}`}
+            >
+              <div className={`mb-4 inline-flex rounded-xl p-3 transition group-hover:scale-110 ${feature.iconBg}`}>{feature.icon}</div>
+              <h4 className="font-display text-xl font-bold text-slate-900">{feature.title}</h4>
+              <p className="mt-2 text-sm text-slate-600">{feature.text}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      {/* HOW IT WORKS */}
+      <section id="how" className="mx-auto max-w-7xl px-4 py-14 sm:px-6 lg:px-8">
+        <div className="mb-10 text-center">
+          <p className="pill mx-auto mb-3">Comment ça marche</p>
+          <h3 className="font-display text-3xl font-extrabold text-slate-900 sm:text-4xl">Trois étapes, zéro friction</h3>
+        </div>
+        <div className="relative grid gap-5 md:grid-cols-3">
+          {steps.map((step, i) => (
+            <div key={step.title} className="card-premium relative p-7">
+              <span className="absolute right-5 top-5 font-display text-5xl font-extrabold text-slate-100">{i + 1}</span>
+              <div className="mb-4 inline-flex h-11 w-11 items-center justify-center rounded-xl bg-gradient-to-br from-indigo-600 to-violet-600 text-white shadow-lg shadow-indigo-300/40">
+                {step.icon}
+              </div>
+              <h4 className="font-display text-lg font-bold text-slate-900">{step.title}</h4>
+              <p className="mt-2 text-sm text-slate-600">{step.text}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* TESTIMONIAL */}
+      <section className="mx-auto max-w-7xl px-4 py-10 sm:px-6 lg:px-8">
+        <div className="relative overflow-hidden rounded-3xl bg-gradient-to-br from-slate-900 via-indigo-950 to-slate-900 p-8 text-white shadow-2xl md:p-12">
+          <div className="absolute -right-10 -top-10 h-48 w-48 rounded-full bg-indigo-500/30 blur-3xl" />
+          <div className="absolute -bottom-10 -left-10 h-48 w-48 rounded-full bg-cyan-500/20 blur-3xl" />
+          <Quote className="h-10 w-10 text-indigo-300" />
+          <p className="mt-4 max-w-3xl font-display text-2xl font-bold leading-snug sm:text-3xl">
+            « En passant au matching sémantique, nous avons divisé par trois le temps de présélection
+            tout en gardant des décisions explicables. »
+          </p>
+          <div className="mt-6 flex items-center gap-3">
+            <div className="flex h-10 w-10 items-center justify-center rounded-full bg-gradient-to-br from-indigo-500 to-violet-500 font-bold">A</div>
+            <div>
+              <p className="font-semibold">Amine R.</p>
+              <p className="text-sm text-indigo-200">Lead Talent Acquisition</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* FAQ */}
+      <section id="faq" className="mx-auto max-w-4xl px-4 py-14 sm:px-6 lg:px-8">
+        <div className="mb-8 text-center">
+          <p className="pill mx-auto mb-3"><MessageSquare className="h-3.5 w-3.5" /> FAQ</p>
+          <h3 className="font-display text-3xl font-extrabold text-slate-900 sm:text-4xl">Questions fréquentes</h3>
+        </div>
+        <div className="space-y-3">
+          {faqs.map((item, idx) => {
+            const open = faqOpen === idx;
+            return (
+              <div key={item.q} className={`card-premium overflow-hidden ${open ? '!border-indigo-300' : ''}`}>
+                <button
+                  onClick={() => setFaqOpen(open ? null : idx)}
+                  className="flex w-full items-center justify-between gap-4 p-5 text-left"
+                >
+                  <span className="font-display text-base font-bold text-slate-900 md:text-lg">{item.q}</span>
+                  <span className={`flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full text-lg transition ${open ? 'rotate-45 bg-indigo-600 text-white' : 'bg-slate-100 text-slate-500'}`}>+</span>
+                </button>
+                <div className={`grid transition-all duration-300 ${open ? 'grid-rows-[1fr] opacity-100' : 'grid-rows-[0fr] opacity-0'}`}>
+                  <p className="overflow-hidden px-5 pb-5 text-sm text-slate-600 md:text-base">{item.a}</p>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </section>
+
+      {/* CONTACT */}
+      <section id="contact" className="mx-auto max-w-7xl px-4 py-14 sm:px-6 lg:px-8">
+        <div className="card-premium grid gap-8 p-8 md:p-10 lg:grid-cols-2">
           <div>
-            <p className="mb-2 text-sm font-bold uppercase tracking-widest text-indigo-600">Contact</p>
-            <h3 className="text-3xl font-extrabold text-slate-900">Parlons de votre besoin</h3>
+            <p className="pill mb-4">Contact</p>
+            <h3 className="font-display text-3xl font-extrabold text-slate-900 sm:text-4xl">Parlons de votre besoin</h3>
             <p className="mt-4 text-slate-600">
               Une démo, un partenariat ou un déploiement ? Laissez un message et nous revenons vers vous rapidement.
             </p>
 
-            <div className="mt-8 space-y-3 text-sm text-slate-600">
-              <p className="rounded-lg bg-slate-50 px-4 py-3">
-                <span className="font-semibold text-slate-900">Support:</span> support@aitalentfinder.example
-              </p>
-              <p className="rounded-lg bg-slate-50 px-4 py-3">
-                <span className="font-semibold text-slate-900">Adresse:</span> 123 Rue de l'IA, Paris
-              </p>
-              <p className="rounded-lg bg-slate-50 px-4 py-3">
-                <span className="font-semibold text-slate-900">Disponibilité:</span> Lun - Ven, 9h à 18h
-              </p>
+            <div className="mt-8 space-y-3 text-sm">
+              {[
+                { k: 'Support', v: 'support@aitalentfinder.example' },
+                { k: 'Adresse', v: "123 Rue de l'IA, Paris" },
+                { k: 'Disponibilité', v: 'Lun - Ven, 9h à 18h' },
+              ].map((c) => (
+                <p key={c.k} className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-slate-600">
+                  <span className="font-semibold text-slate-900">{c.k}:</span> {c.v}
+                </p>
+              ))}
             </div>
           </div>
 
           <form
-            className="rounded-2xl border border-slate-200 bg-slate-50 p-5"
+            className="rounded-2xl border border-slate-200 bg-slate-50 p-5 sm:p-6"
             onSubmit={async (e) => {
               e.preventDefault();
               setContactSubmitting(true);
@@ -375,27 +438,23 @@ export default function Home() {
                 name="name"
                 required
                 placeholder="Votre nom"
-                className="w-full rounded-lg border border-slate-300 bg-white px-4 py-3 text-slate-900 outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+                className="w-full rounded-xl border border-slate-300 bg-white px-4 py-3 text-slate-900 outline-none transition focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200"
               />
               <input
                 name="email"
                 type="email"
                 required
                 placeholder="Email"
-                className="w-full rounded-lg border border-slate-300 bg-white px-4 py-3 text-slate-900 outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+                className="w-full rounded-xl border border-slate-300 bg-white px-4 py-3 text-slate-900 outline-none transition focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200"
               />
               <textarea
                 name="message"
                 required
                 rows={5}
                 placeholder="Votre message"
-                className="w-full rounded-lg border border-slate-300 bg-white px-4 py-3 text-slate-900 outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+                className="w-full rounded-xl border border-slate-300 bg-white px-4 py-3 text-slate-900 outline-none transition focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200"
               />
-              <button
-                type="submit"
-                disabled={contactSubmitting}
-                className="inline-flex w-full items-center justify-center gap-2 rounded-lg bg-gradient-to-r from-blue-600 to-indigo-600 px-5 py-3 font-semibold text-white transition hover:from-blue-700 hover:to-indigo-700 disabled:cursor-not-allowed disabled:opacity-70"
-              >
+              <button type="submit" disabled={contactSubmitting} className="btn-primary w-full disabled:cursor-not-allowed disabled:opacity-70">
                 {contactSubmitting ? 'Envoi en cours...' : 'Envoyer le message'}
                 {!contactSubmitting && <ArrowRight className="h-4 w-4" />}
               </button>
@@ -405,84 +464,40 @@ export default function Home() {
         </div>
       </section>
 
-      <section className="mx-auto max-w-7xl px-4 pb-14 pt-4 sm:px-6 sm:pb-16 sm:pt-6 lg:px-8">
-        <div className="rounded-2xl bg-gradient-to-r from-blue-600 to-indigo-700 p-8 text-center text-white shadow-xl shadow-blue-200">
-          <ShieldCheck className="mx-auto mb-3 h-8 w-8 text-cyan-200" />
-          <h3 className="text-2xl font-extrabold">Passez a un recrutement plus intelligent</h3>
-          <p className="mx-auto mt-2 max-w-2xl text-blue-100">
-            Activez votre espace en quelques minutes et obtenez des recommandations pertinentes des le premier jour.
-          </p>
-          <Link
-            href="/auth/register"
-            className="mt-5 inline-flex items-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-blue-700 transition hover:bg-blue-50"
-          >
-            Lancer ma premiere recherche
-            <ArrowRight className="h-4 w-4" />
-          </Link>
+      {/* CTA */}
+      <section className="mx-auto max-w-7xl px-4 pb-16 pt-4 sm:px-6 lg:px-8">
+        <div className="relative overflow-hidden rounded-3xl bg-gradient-to-r from-blue-600 via-indigo-600 to-violet-600 p-10 text-center text-white shadow-2xl shadow-indigo-300/40">
+          <div className="absolute inset-0 grid-overlay opacity-20" />
+          <div className="relative">
+            <Sparkles className="mx-auto mb-3 h-9 w-9 text-cyan-200" />
+            <h3 className="font-display text-3xl font-extrabold sm:text-4xl">Passez à un recrutement plus intelligent</h3>
+            <p className="mx-auto mt-3 max-w-2xl text-indigo-100">
+              Activez votre espace en quelques minutes et obtenez des recommandations pertinentes dès le premier jour.
+            </p>
+            <Link
+              href="/auth/register"
+              className="mt-6 inline-flex items-center gap-2 rounded-xl bg-white px-7 py-3.5 font-bold text-indigo-700 shadow-lg transition hover:-translate-y-0.5 hover:bg-indigo-50"
+            >
+              Lancer ma première recherche
+              <ArrowRight className="h-4 w-4" />
+            </Link>
+          </div>
         </div>
       </section>
 
-      <footer className="border-t border-slate-200 bg-white py-8">
-        <div className="mx-auto flex max-w-7xl flex-col items-center justify-between gap-3 px-4 text-sm text-slate-500 sm:flex-row sm:px-6 lg:px-8">
-          <p>&copy; 2026 AI Talent Finder. Tous droits reserves.</p>
-          <p className="font-semibold text-slate-700">Recruiting Intelligence Platform</p>
+      {/* FOOTER */}
+      <footer className="border-t border-slate-200 bg-white py-10">
+        <div className="mx-auto flex max-w-7xl flex-col items-center justify-between gap-4 px-4 sm:flex-row sm:px-6 lg:px-8">
+          <div className="flex items-center gap-3">
+            <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-gradient-to-br from-blue-600 to-indigo-600 text-white">
+              <Sparkles className="h-4 w-4" />
+            </div>
+            <p className="font-display font-bold text-slate-900">AI Talent Finder</p>
+          </div>
+          <p className="text-sm text-slate-500">&copy; 2026 AI Talent Finder. Tous droits réservés.</p>
+          <p className="text-sm font-semibold text-slate-700">Recruiting Intelligence Platform</p>
         </div>
       </footer>
-
-      <style jsx>{`
-        .hero-grid {
-          background-image: linear-gradient(to right, rgba(100, 116, 139, 0.08) 1px, transparent 1px),
-            linear-gradient(to bottom, rgba(100, 116, 139, 0.08) 1px, transparent 1px);
-          background-size: 36px 36px;
-          mask-image: radial-gradient(circle at center, black 38%, transparent 85%);
-        }
-
-        .animate-slide-up {
-          animation: slide-up 0.7s ease-out;
-        }
-
-        .animate-float {
-          animation: float-in 0.9s ease-out;
-        }
-
-        .animate-rise {
-          opacity: 0;
-          animation: rise-in 0.55s ease-out forwards;
-        }
-
-        @keyframes slide-up {
-          from {
-            opacity: 0;
-            transform: translateY(16px);
-          }
-          to {
-            opacity: 1;
-            transform: translateY(0);
-          }
-        }
-
-        @keyframes float-in {
-          from {
-            opacity: 0;
-            transform: translateY(18px) scale(0.98);
-          }
-          to {
-            opacity: 1;
-            transform: translateY(0) scale(1);
-          }
-        }
-
-        @keyframes rise-in {
-          from {
-            opacity: 0;
-            transform: translateY(10px);
-          }
-          to {
-            opacity: 1;
-            transform: translateY(0);
-          }
-        }
-      `}</style>
     </div>
   );
 }

--- a/frontend/src/app/recruiter/chatbot/page.tsx
+++ b/frontend/src/app/recruiter/chatbot/page.tsx
@@ -181,11 +181,16 @@ export default function ChatbotPage() {
       {/* Header */}
       <div className="bg-white border-b border-gray-200 px-6 py-4 shadow-sm">
         <div className="flex items-center gap-3">
-          <MessageCircle className="w-6 h-6 text-indigo-600" />
+          <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-gradient-to-br from-indigo-600 to-violet-600 text-white shadow-lg shadow-indigo-300/40">
+            <MessageCircle className="h-5 w-5" />
+          </div>
           <div>
-            <h1 className="text-2xl font-bold text-gray-900">Assistant Recruteur IA</h1>
+            <h1 className="font-display text-2xl font-extrabold text-gray-900">Assistant Recruteur IA</h1>
             <p className="text-sm text-gray-600">Posez vos questions sur les candidats et les matchings</p>
           </div>
+          <span className="ml-auto hidden items-center gap-1.5 rounded-full bg-emerald-100 px-3 py-1 text-xs font-bold text-emerald-700 sm:inline-flex">
+            <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" /> En ligne
+          </span>
         </div>
       </div>
 
@@ -213,15 +218,15 @@ export default function ChatbotPage() {
             value={input}
             onChange={e => setInput(e.target.value)}
             placeholder="Posez une question sur les candidats..."
-            className="flex-1 px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            className="flex-1 rounded-xl border border-gray-300 bg-white px-4 py-3 outline-none transition focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200"
             disabled={loading}
           />
           <button
             type="submit"
             disabled={loading || !input.trim()}
-            className="bg-indigo-600 hover:bg-indigo-700 disabled:bg-gray-400 text-white px-6 py-3 rounded-lg font-medium flex items-center gap-2 transition"
+            className="btn-primary !rounded-xl disabled:cursor-not-allowed disabled:opacity-60"
           >
-            <Send className="w-4 h-4" />
+            <Send className="h-4 w-4" />
             Envoyer
           </button>
         </form>

--- a/frontend/src/app/recruiter/dashboard/page.tsx
+++ b/frontend/src/app/recruiter/dashboard/page.tsx
@@ -7,7 +7,7 @@ import { candidatesApi } from '@/services/candidates';
 import { favoritesApi } from '@/services/favorites';
 import { criteriaApi } from '@/services/criteria';
 import Layout from '@/components/Layout';
-import { Upload, Users, GitCompareArrows, Star, Clock, ArrowRight } from 'lucide-react';
+import { Upload, Users, GitCompareArrows, Star, Clock, ArrowRight, Target, Sparkles } from 'lucide-react';
 
 /*
  * C1 - Bloc "mode recherche" supprime du dashboard.
@@ -81,158 +81,127 @@ export default function RecruiterDashboard() {
     {
       label: 'Candidats',
       value: stats.candidateCount,
-      color: 'blue',
       href: '/candidates',
-      emoji: '👥',
+      icon: Users,
+      grad: 'from-blue-500 to-indigo-500',
+      text: 'text-blue-600',
       sub: 'dans la base',
     },
     {
-      label: 'Criteres de poste',
+      label: 'Critères de poste',
       value: stats.criteriaCount,
-      color: 'purple',
       href: '/matching',
-      emoji: '🎯',
-      sub: 'crees',
+      icon: Target,
+      grad: 'from-violet-500 to-fuchsia-500',
+      text: 'text-violet-600',
+      sub: 'créés',
     },
     {
       label: 'En shortlist',
       value: stats.favoritesCount,
-      color: 'green',
       href: '/recruiter/shortlist',
-      emoji: '⭐',
+      icon: Star,
+      grad: 'from-emerald-500 to-teal-500',
+      text: 'text-emerald-600',
       sub: 'favoris',
     },
   ];
 
-  const colorMap: Record<string, string> = {
-    blue: 'border-blue-500 text-blue-600',
-    purple: 'border-purple-500 text-purple-600',
-    green: 'border-green-500 text-green-600',
-  };
-
   const quickActions = [
-    {
-      label: 'Uploader un CV',
-      href: '/candidate/upload',
-      icon: Upload,
-      color: 'bg-indigo-600 hover:bg-indigo-700',
-    },
-    {
-      label: 'Voir tous les candidats',
-      href: '/candidates',
-      icon: Users,
-      color: 'bg-blue-600 hover:bg-blue-700',
-    },
-    {
-      label: 'Lancer un matching',
-      href: '/matching',
-      icon: GitCompareArrows,
-      color: 'bg-purple-600 hover:bg-purple-700',
-    },
+    { label: 'Uploader un CV', href: '/candidate/upload', icon: Upload },
+    { label: 'Voir tous les candidats', href: '/candidates', icon: Users },
+    { label: 'Lancer un matching', href: '/matching', icon: GitCompareArrows },
   ];
 
   return (
     <Layout>
-      <div className="max-w-6xl mx-auto px-4 py-8 space-y-8">
-        {/* Header */}
-        <div className="bg-white rounded-xl shadow-md p-8 border-l-4 border-purple-500">
-          <h2 className="text-3xl font-bold text-gray-900 mb-1">
-            Bonjour{userName ? `, ${userName}` : ''} !
-          </h2>
-          <p className="text-gray-600 text-lg">
-            Bienvenue sur votre tableau de bord recruteur.
-          </p>
+      <div className="max-w-6xl mx-auto space-y-7">
+        {/* Greeting header */}
+        <div className="relative overflow-hidden rounded-3xl bg-gradient-to-br from-indigo-600 via-violet-600 to-indigo-700 p-8 text-white shadow-xl shadow-indigo-300/30">
+          <div className="absolute -right-8 -top-10 h-44 w-44 rounded-full bg-white/10 blur-2xl" />
+          <div className="absolute right-24 bottom-[-3rem] h-40 w-40 rounded-full bg-cyan-400/20 blur-2xl" />
+          <div className="relative">
+            <span className="inline-flex items-center gap-1.5 rounded-full bg-white/15 px-3 py-1 text-xs font-semibold backdrop-blur">
+              <Sparkles className="h-3.5 w-3.5" /> Espace Recruteur
+            </span>
+            <h2 className="font-display mt-3 text-3xl font-extrabold sm:text-4xl">
+              Bonjour{userName ? `, ${userName}` : ''} 👋
+            </h2>
+            <p className="mt-1 text-indigo-100">Bienvenue sur votre tableau de bord recruteur.</p>
+          </div>
         </div>
 
         {/* Stats */}
-        <div className="grid md:grid-cols-3 gap-4">
-          {statCards.map(({ label, value, color, href, emoji, sub }) => (
-            <Link
-              key={href}
-              href={href}
-              className={`bg-white rounded-xl shadow-md p-6 border-l-4 ${colorMap[color].split(' ')[0]} hover:shadow-lg transition-shadow`}
-            >
-              <div className="flex items-center justify-between">
+        <div className="grid gap-4 md:grid-cols-3">
+          {statCards.map(({ label, value, href, icon: Icon, grad, text, sub }) => (
+            <Link key={href} href={href} className="card-premium card-glow group p-6">
+              <div className="flex items-start justify-between">
                 <div>
-                  <div className={`text-3xl font-bold ${colorMap[color].split(' ')[1]}`}>
-                    {stats.loading ? (
-                      <span className="text-lg text-gray-400">...</span>
-                    ) : (
-                      value
-                    )}
+                  <div className={`font-display text-4xl font-extrabold ${text}`}>
+                    {stats.loading ? <span className="text-lg text-gray-400">...</span> : value}
                   </div>
-                  <div className="text-gray-600 font-medium">{label}</div>
-                  <div className="text-xs text-gray-400 mt-1">{sub}</div>
+                  <div className="mt-1 font-semibold text-gray-700">{label}</div>
+                  <div className="mt-0.5 text-xs text-gray-400">{sub}</div>
                 </div>
-                <div className="text-3xl">{emoji}</div>
+                <div className={`flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br ${grad} text-white shadow-lg transition-transform group-hover:scale-110`}>
+                  <Icon className="h-6 w-6" />
+                </div>
               </div>
             </Link>
           ))}
         </div>
 
         {/* Raccourcis rapides */}
-        <div className="bg-white rounded-xl shadow-md p-6">
-          <h3 className="text-xl font-bold text-gray-900 mb-4">Raccourcis rapides</h3>
+        <div className="card-premium p-6">
+          <h3 className="font-display mb-4 text-xl font-bold text-gray-900">Raccourcis rapides</h3>
           <div className="flex flex-wrap gap-3">
-            {quickActions.map(({ label, href, icon: Icon, color }) => (
-              <Link
-                key={href}
-                href={href}
-                className={`inline-flex items-center gap-2 px-5 py-2.5 rounded-lg text-sm font-semibold text-white transition-colors ${color}`}
-              >
-                <Icon className="h-4 w-4" />
+            {quickActions.map(({ label, href, icon: Icon }) => (
+              <Link key={href} href={href} className="btn-ghost group">
+                <Icon className="h-4 w-4 text-indigo-600" />
                 {label}
+                <ArrowRight className="h-4 w-4 text-gray-400 transition group-hover:translate-x-0.5 group-hover:text-indigo-600" />
               </Link>
             ))}
           </div>
         </div>
 
         {/* Derniers candidats ajoutes */}
-        <div className="bg-white rounded-xl shadow-md p-6">
-          <div className="flex items-center justify-between mb-4">
-            <h3 className="text-xl font-bold text-gray-900 flex items-center gap-2">
-              <Clock className="h-5 w-5 text-indigo-500" />
-              Derniers candidats ajoutes
+        <div className="card-premium p-6">
+          <div className="mb-4 flex items-center justify-between">
+            <h3 className="font-display flex items-center gap-2 text-xl font-bold text-gray-900">
+              <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-indigo-100 text-indigo-600"><Clock className="h-4.5 w-4.5" /></span>
+              Derniers candidats ajoutés
             </h3>
-            <Link
-              href="/candidates"
-              className="text-sm text-indigo-600 hover:text-indigo-800 font-medium flex items-center gap-1"
-            >
+            <Link href="/candidates" className="flex items-center gap-1 text-sm font-semibold text-indigo-600 hover:text-indigo-800">
               Voir tous <ArrowRight className="h-4 w-4" />
             </Link>
           </div>
 
           {stats.loading ? (
-            <div className="text-gray-400 text-sm py-4 text-center">Chargement...</div>
+            <div className="py-4 text-center text-sm text-gray-400">Chargement...</div>
           ) : recentCandidates.length === 0 ? (
-            <div className="text-center py-8 text-gray-500">
-              <div className="text-4xl mb-2">📂</div>
+            <div className="py-8 text-center text-gray-500">
+              <div className="mb-2 text-4xl">📂</div>
               <p>Aucun candidat pour l&apos;instant. Commencez par uploader un CV.</p>
-              <Link
-                href="/candidate/upload"
-                className="mt-3 inline-block text-indigo-600 hover:underline font-medium"
-              >
+              <Link href="/candidate/upload" className="mt-3 inline-block font-semibold text-indigo-600 hover:underline">
                 Uploader un CV
               </Link>
             </div>
           ) : (
             <ul className="divide-y divide-gray-100">
               {recentCandidates.map((c) => (
-                <li key={c.id} className="py-3 flex items-center justify-between">
+                <li key={c.id} className="group flex items-center justify-between rounded-xl px-2 py-3 transition hover:bg-gray-50">
                   <div className="flex items-center gap-3">
-                    <div className="h-9 w-9 rounded-full bg-indigo-100 flex items-center justify-center text-indigo-700 font-bold text-sm flex-shrink-0">
+                    <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-indigo-500 to-violet-500 text-sm font-bold text-white">
                       {(c.full_name || 'C')[0].toUpperCase()}
                     </div>
                     <div>
-                      <p className="font-medium text-gray-900">{c.full_name}</p>
+                      <p className="font-semibold text-gray-900">{c.full_name}</p>
                       <p className="text-xs text-gray-500">{c.email}</p>
                     </div>
                   </div>
-                  <Link
-                    href={`/candidates/${c.id}`}
-                    className="text-sm text-indigo-600 hover:text-indigo-800 font-medium flex items-center gap-1"
-                  >
-                    Voir <ArrowRight className="h-3.5 w-3.5" />
+                  <Link href={`/candidates/${c.id}`} className="flex items-center gap-1 text-sm font-semibold text-indigo-600 hover:text-indigo-800">
+                    Voir <ArrowRight className="h-3.5 w-3.5 transition group-hover:translate-x-0.5" />
                   </Link>
                 </li>
               ))}
@@ -241,27 +210,22 @@ export default function RecruiterDashboard() {
         </div>
 
         {/* Shortlist rapide */}
-        <div className="bg-white rounded-xl shadow-md p-6">
-          <div className="flex items-center justify-between mb-4">
-            <h3 className="text-xl font-bold text-gray-900 flex items-center gap-2">
-              <Star className="h-5 w-5 text-yellow-500" />
+        <div className="card-premium overflow-hidden p-6">
+          <div className="mb-3 flex items-center justify-between">
+            <h3 className="font-display flex items-center gap-2 text-xl font-bold text-gray-900">
+              <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-amber-100 text-amber-600"><Star className="h-4.5 w-4.5" /></span>
               Ma shortlist
             </h3>
-            <Link
-              href="/recruiter/shortlist"
-              className="text-sm text-indigo-600 hover:text-indigo-800 font-medium flex items-center gap-1"
-            >
+            <Link href="/recruiter/shortlist" className="flex items-center gap-1 text-sm font-semibold text-indigo-600 hover:text-indigo-800">
               Voir la shortlist <ArrowRight className="h-4 w-4" />
             </Link>
           </div>
-          <p className="text-gray-600 text-sm">
-            {stats.loading ? (
-              '...'
-            ) : stats.favoritesCount === 0 ? (
-              'Aucun candidat en shortlist. Ajoutez vos favoris depuis la liste des candidats.'
-            ) : (
-              `Vous avez ${stats.favoritesCount} candidat${stats.favoritesCount > 1 ? 's' : ''} en shortlist.`
-            )}
+          <p className="text-sm text-gray-600">
+            {stats.loading
+              ? '...'
+              : stats.favoritesCount === 0
+              ? 'Aucun candidat en shortlist. Ajoutez vos favoris depuis la liste des candidats.'
+              : `Vous avez ${stats.favoritesCount} candidat${stats.favoritesCount > 1 ? 's' : ''} en shortlist.`}
           </p>
         </div>
       </div>

--- a/frontend/src/app/recruiter/export/page.tsx
+++ b/frontend/src/app/recruiter/export/page.tsx
@@ -100,11 +100,11 @@ export default function ExportPage() {
       <div className="max-w-4xl mx-auto">
         {/* Header */}
         <div className="mb-8">
-          <h1 className="text-3xl font-bold text-gray-900 flex items-center gap-3">
-            <Download className="w-8 h-8 text-indigo-600" />
+          <h1 className="font-display flex items-center gap-3 text-3xl font-extrabold text-gray-900">
+            <span className="flex h-10 w-10 items-center justify-center rounded-xl bg-gradient-to-br from-indigo-600 to-violet-600 text-white shadow-lg shadow-indigo-200/50"><Download className="h-5 w-5" /></span>
             Exporter les Résultats
           </h1>
-          <p className="text-gray-600 mt-2">
+          <p className="mt-2 text-gray-600">
             Téléchargez les candidats et les résultats de matching dans le format de votre choix
           </p>
         </div>
@@ -129,10 +129,10 @@ export default function ExportPage() {
             <button
               key={option.id}
               onClick={() => setSelectedFormat(option.id)}
-              className={`p-6 rounded-lg border-2 transition-all ${
+              className={`rounded-2xl border-2 p-6 text-left transition-all ${
                 selectedFormat === option.id
-                  ? "border-indigo-600 bg-indigo-50 shadow-lg"
-                  : "border-gray-200 bg-white hover:border-gray-300"
+                  ? "border-indigo-600 bg-indigo-50 shadow-lg shadow-indigo-100"
+                  : "border-gray-200 bg-white hover:-translate-y-1 hover:border-indigo-300 hover:shadow-md"
               }`}
             >
               <div className={`w-12 h-12 rounded-lg bg-gradient-to-br ${option.color} text-white flex items-center justify-center mb-4`}>
@@ -150,8 +150,8 @@ export default function ExportPage() {
         </div>
 
         {/* Settings */}
-        <div className="bg-white rounded-lg p-6 border border-gray-200 mb-6">
-          <h2 className="text-lg font-bold text-gray-900 mb-4">Options d'export</h2>
+        <div className="card-premium p-6 mb-6">
+          <h2 className="font-display text-lg font-bold text-gray-900 mb-4">Options d&apos;export</h2>
 
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
             {/* Include Options */}
@@ -230,7 +230,7 @@ export default function ExportPage() {
           <button
             onClick={handleExport}
             disabled={loading || !selectedFormat}
-            className="flex-1 bg-indigo-600 hover:bg-indigo-700 disabled:bg-gray-400 text-white py-3 rounded-lg font-semibold flex items-center justify-center gap-2 transition"
+            className="btn-primary flex-1 disabled:cursor-not-allowed disabled:opacity-50"
           >
             {loading ? (
               <>
@@ -244,10 +244,7 @@ export default function ExportPage() {
               </>
             )}
           </button>
-          <button
-            onClick={() => window.history.back()}
-            className="px-6 py-3 border border-gray-300 rounded-lg font-semibold text-gray-700 hover:bg-gray-50 transition"
-          >
+          <button onClick={() => window.history.back()} className="btn-ghost">
             Retour
           </button>
         </div>

--- a/frontend/src/app/recruiter/feedback/page.tsx
+++ b/frontend/src/app/recruiter/feedback/page.tsx
@@ -223,7 +223,7 @@ export default function RecruiterFeedbackPage() {
                 <Sparkles className="h-4 w-4" />
                 Phase 3 - Feedback Loop
               </div>
-              <h1 className="text-4xl font-black tracking-tight sm:text-5xl">
+              <h1 className="font-display text-4xl font-extrabold tracking-tight sm:text-5xl">
                 Boucle de feedback, recommandations et conformité
               </h1>
               <p className="mt-4 text-base leading-7 text-slate-300 sm:text-lg">
@@ -292,11 +292,7 @@ export default function RecruiterFeedbackPage() {
               </div>
 
               <div className="md:col-span-2 flex flex-wrap gap-3">
-                <button
-                  type="submit"
-                  disabled={working}
-                  className="inline-flex items-center justify-center rounded-full bg-indigo-600 px-5 py-3 text-sm font-semibold text-white transition hover:bg-indigo-700 disabled:cursor-not-allowed disabled:opacity-60"
-                >
+                <button type="submit" disabled={working} className="btn-primary disabled:cursor-not-allowed disabled:opacity-60">
                   {working ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
                   Enregistrer le feedback
                 </button>
@@ -305,7 +301,7 @@ export default function RecruiterFeedbackPage() {
                   onClick={() => {
                     void loadOverview();
                   }}
-                  className="inline-flex items-center justify-center rounded-full border border-slate-300 bg-white px-5 py-3 text-sm font-semibold text-slate-700 transition hover:bg-slate-50"
+                  className="btn-ghost"
                 >
                   Rafraîchir les stats
                 </button>

--- a/frontend/src/app/recruiter/shortlist/page.tsx
+++ b/frontend/src/app/recruiter/shortlist/page.tsx
@@ -143,16 +143,19 @@ export default function RecruiterShortlist() {
 
   return (
     <Layout>
-      <div className="max-w-6xl mx-auto px-4 py-8">
-        <div className="bg-white rounded-xl shadow-md p-8 mb-8 border-l-4 border-purple-500">
-          <h2 className="text-3xl font-bold text-gray-900 mb-2">Tes Candidats en Shortlist 📋</h2>
-          <p className="text-gray-600 text-lg">
-            {loading
-              ? '⏳ Chargement...'
-              : showingFallbackCandidates
-                ? `Aucun favori trouvé. Affichage de ${shortlist.length} candidats disponibles.`
-                : `Total: ${shortlist.length} candidats sélectionnés`}
-          </p>
+      <div className="max-w-6xl mx-auto">
+        <div className="relative mb-8 overflow-hidden rounded-3xl bg-gradient-to-br from-violet-600 via-indigo-600 to-purple-700 p-8 text-white shadow-xl shadow-indigo-300/30">
+          <div className="absolute -right-8 -top-10 h-44 w-44 rounded-full bg-white/10 blur-2xl" />
+          <div className="relative">
+            <h2 className="font-display text-3xl font-extrabold sm:text-4xl">Tes Candidats en Shortlist 📋</h2>
+            <p className="mt-1.5 text-indigo-100">
+              {loading
+                ? '⏳ Chargement...'
+                : showingFallbackCandidates
+                  ? `Aucun favori trouvé. Affichage de ${shortlist.length} candidats disponibles.`
+                  : `Total: ${shortlist.length} candidats sélectionnés`}
+            </p>
+          </div>
           {/* Dev-only debug: show raw /api/candidates response to help troubleshooting */}
           {process.env.NODE_ENV !== 'production' && (
             <div className="mt-4 p-3 border rounded bg-gray-50">
@@ -191,12 +194,12 @@ export default function RecruiterShortlist() {
         )}
 
         {loading ? (
-          <div className="bg-white rounded-xl shadow-md p-12 text-center">
+          <div className="card-premium p-12 text-center">
             <div className="text-5xl mb-4 animate-bounce">⏳</div>
             <p className="text-gray-600 text-lg font-medium">Chargement de vos favoris...</p>
           </div>
         ) : shortlist.length === 0 ? (
-          <div className="bg-white rounded-xl shadow-md p-12 text-center">
+          <div className="card-premium p-12 text-center">
             <div className="text-6xl mb-4">📭</div>
             <p className="text-gray-600 text-lg font-medium">Aucun candidat en shortlist</p>
             <p className="text-gray-500 mt-2 mb-6">
@@ -206,10 +209,7 @@ export default function RecruiterShortlist() {
               </Link>{' '}
               pour ajouter des candidats
             </p>
-            <Link
-              href="/recruiter/dashboard"
-              className="inline-block px-6 py-3 bg-gradient-to-r from-purple-600 to-purple-700 text-white rounded-lg hover:from-purple-700 hover:to-purple-800 transition-all font-semibold"
-            >
+            <Link href="/recruiter/dashboard" className="btn-primary inline-flex">
               Aller au Dashboard
             </Link>
           </div>
@@ -219,7 +219,7 @@ export default function RecruiterShortlist() {
               {shortlist.map((item, idx) => (
                 <div
                   key={item.favorite_id}
-                  className="p-6 border border-gray-200 rounded-xl hover:shadow-lg hover:border-purple-300 transition-all duration-300 bg-white"
+                  className="card-premium card-glow p-6"
                   role="listitem"
                   aria-label={`${item.candidate.full_name}, ${item.candidate.email}, score: ${formatPercent(item.candidate.extraction_quality_score)}%`}
                   style={{ animationDelay: `${idx * 50}ms` }}
@@ -272,7 +272,7 @@ export default function RecruiterShortlist() {
             </div>
 
             {shortlist.length > 0 && (
-              <div className="bg-white rounded-xl shadow-md p-6 border-t-4 border-green-500">
+              <div className="card-premium p-6 border-t-4 border-green-500">
                 <div className="flex items-center justify-between">
                   <div>
                     <h3 className="font-bold text-gray-900 text-lg">Exporter les candidats</h3>

--- a/frontend/src/app/scoring/page.tsx
+++ b/frontend/src/app/scoring/page.tsx
@@ -79,17 +79,17 @@ export default function ScoringPage() {
   return (
     <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 p-8">
       <div className="max-w-6xl mx-auto">
-        <h1 className="text-4xl font-bold text-gray-800 mb-2">Advanced Scoring Demo</h1>
+        <h1 className="font-display text-4xl font-extrabold text-gray-900 mb-2">Advanced Scoring Demo</h1>
         <p className="text-gray-600 mb-8">
           Test the intelligent CV-Job matching system with calibrated business rules
         </p>
 
         {/* Load Test Dataset Button */}
-        <div className="bg-white rounded-lg shadow-md p-6 mb-8">
+        <div className="card-premium p-6 mb-8">
           <button
             onClick={loadTestDataset}
             disabled={loading}
-            className="px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:bg-gray-400 transition"
+            className="btn-primary disabled:cursor-not-allowed disabled:opacity-50"
           >
             {loading && testDataset === null ? "Loading..." : "Load Test Dataset"}
           </button>
@@ -104,7 +104,7 @@ export default function ScoringPage() {
         {testDataset && (
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 mb-8">
             {/* Candidates Column */}
-            <div className="bg-white rounded-lg shadow-md p-6">
+            <div className="card-premium p-6">
               <h2 className="text-2xl font-bold mb-4 text-gray-800">Candidates</h2>
               <div className="space-y-2 max-h-72 overflow-y-auto">
                 {testDataset.candidates.map((cand, idx) => (
@@ -128,7 +128,7 @@ export default function ScoringPage() {
             </div>
 
             {/* Jobs Column */}
-            <div className="bg-white rounded-lg shadow-md p-6">
+            <div className="card-premium p-6">
               <h2 className="text-2xl font-bold mb-4 text-gray-800">Jobs</h2>
               <div className="space-y-2 max-h-72 overflow-y-auto">
                 {testDataset.jobs.map((job, idx) => (
@@ -155,7 +155,7 @@ export default function ScoringPage() {
 
         {/* Match Result */}
         {selectedCandidate && selectedJob && (
-          <div className="bg-white rounded-lg shadow-md p-6 mb-8">
+          <div className="card-premium p-6 mb-8">
             <div className="mb-4 flex justify-between items-center">
               <h3 className="text-xl font-bold text-gray-800">
                 {selectedCandidate.full_name} ↔ {selectedJob.title}
@@ -163,7 +163,7 @@ export default function ScoringPage() {
               <button
                 onClick={computeScore}
                 disabled={loading}
-                className="px-6 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 disabled:bg-gray-400 transition"
+                className="btn-primary !py-2 disabled:cursor-not-allowed disabled:opacity-50"
               >
                 {loading ? "Computing..." : "Compute Score"}
               </button>

--- a/frontend/src/app/skills/page.tsx
+++ b/frontend/src/app/skills/page.tsx
@@ -30,14 +30,20 @@ export default function SkillsPage() {
   const byCategory = (cat: string) => (skills || []).filter(s => s.category === cat);
 
   return <Layout><div className="max-w-3xl mx-auto space-y-6">
-    <div><h1 className="text-2xl font-bold text-gray-900">Compétences</h1><p className="text-sm text-gray-500 mt-1">Gérer le dictionnaire — <code className="bg-gray-100 px-1 rounded text-xs">GET/POST/DELETE /skills/</code></p></div>
+    <div>
+      <h1 className="font-display flex items-center gap-2.5 text-3xl font-extrabold text-gray-900">
+        <span className="flex h-9 w-9 items-center justify-center rounded-xl bg-gradient-to-br from-indigo-500 to-violet-500 text-white shadow-lg shadow-indigo-200/50"><Plus className="h-5 w-5" /></span>
+        Compétences
+      </h1>
+      <p className="mt-1.5 text-sm text-gray-500">Gérer le dictionnaire de compétences utilisé par le moteur de matching.</p>
+    </div>
 
     {/* Formulaire d'ajout */}
-    <div className="bg-white rounded-xl border border-gray-200 p-5">
+    <div className="card-premium p-5">
       <form onSubmit={addSkill} className="flex items-end gap-3">
         <div className="flex-1"><label className="block text-sm font-medium text-gray-700 mb-1">Nom</label><input type="text" value={name} onChange={e=>setName(e.target.value)} placeholder="Ex: Python, Docker..." className="w-full px-4 py-2.5 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-indigo-500 focus:border-transparent outline-none" /></div>
         <div><label className="block text-sm font-medium text-gray-700 mb-1">Catégorie</label><select value={category} onChange={e=>setCategory(e.target.value)} className="px-4 py-2.5 border border-gray-300 rounded-lg text-sm outline-none focus:ring-2 focus:ring-indigo-500"><option value="tech">Tech</option><option value="soft">Soft skill</option><option value="language">Langue</option></select></div>
-        <button type="submit" disabled={adding||!name.trim()} className="flex items-center gap-1 px-4 py-2.5 bg-indigo-600 text-white rounded-lg text-sm font-medium hover:bg-indigo-700 disabled:opacity-50 transition-colors">{adding?<Loader2 className="h-4 w-4 animate-spin" />:<Plus className="h-4 w-4" />}Ajouter</button>
+        <button type="submit" disabled={adding||!name.trim()} className="btn-primary !py-2.5 text-sm disabled:opacity-50">{adding?<Loader2 className="h-4 w-4 animate-spin" />:<Plus className="h-4 w-4" />}Ajouter</button>
       </form>
       {error && <p className="text-sm text-red-600 mt-2">{error}</p>}
     </div>
@@ -48,7 +54,7 @@ export default function SkillsPage() {
         const items = byCategory(cat);
         if (!items.length) return null;
         const label = {tech:"Compétences techniques",soft:"Soft skills",language:"Langues"}[cat];
-        return <div key={cat} className="bg-white rounded-xl border border-gray-200 p-5">
+        return <div key={cat} className="card-premium p-5">
           <h2 className="text-sm font-semibold text-gray-900 mb-3">{label} ({items.length})</h2>
           <div className="flex flex-wrap gap-2">{items.map(s => <div key={s.id} className="flex items-center gap-1 group">
             <SkillBadge name={s.name} category={s.category} />

--- a/frontend/src/components/ChatMessage.tsx
+++ b/frontend/src/components/ChatMessage.tsx
@@ -15,7 +15,7 @@ export default function ChatMessage({ message }: { message: Message }) {
       <div
         className={`max-w-md rounded-2xl px-4 py-3 ${
           isUser
-            ? "rounded-br-sm bg-slate-950 text-white"
+            ? "rounded-br-sm bg-gradient-to-br from-indigo-600 to-violet-600 text-white shadow-md shadow-indigo-300/30"
             : "rounded-bl-sm border border-slate-200 bg-white text-slate-900 shadow-sm"
         }`}
       >

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -68,10 +68,12 @@ export default function Layout({ children }: { children: React.ReactNode }) {
   const SidebarContent = ({ mobile = false }: { mobile?: boolean }) => (
     <>
       {/* Header */}
-      <div className="h-16 flex items-center gap-2 px-4 border-b border-gray-200 flex-shrink-0">
-        <BrainCircuit className="h-7 w-7 text-indigo-600 flex-shrink-0" />
+      <div className="h-16 flex items-center gap-2.5 px-4 border-b border-gray-200 flex-shrink-0">
+        <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-indigo-600 to-violet-600 text-white shadow-lg shadow-indigo-300/40">
+          <BrainCircuit className="h-5 w-5" />
+        </div>
         {(sidebarOpen || mobile) && (
-          <span className="text-lg font-bold text-gray-900 truncate">AI Talent Finder</span>
+          <span className="font-display text-lg font-bold text-gray-900 truncate">AI Talent Finder</span>
         )}
         {mobile && (
           <button onClick={() => setMobileOpen(false)} className="ml-auto p-1 text-gray-400 hover:text-gray-600">
@@ -105,13 +107,13 @@ export default function Layout({ children }: { children: React.ReactNode }) {
               key={href}
               href={href}
               title={!sidebarOpen && !mobile ? label : undefined}
-              className={`flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-colors ${
+              className={`group relative flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-semibold transition-all ${
                 active
-                  ? "bg-indigo-50 text-indigo-700"
+                  ? "bg-gradient-to-r from-indigo-600 to-violet-600 text-white shadow-md shadow-indigo-300/40"
                   : "text-gray-600 hover:bg-gray-100 hover:text-gray-900"
               }`}
             >
-              <Icon className="h-5 w-5 flex-shrink-0" />
+              <Icon className={`h-5 w-5 flex-shrink-0 transition-transform group-hover:scale-110 ${active ? "" : "text-gray-400 group-hover:text-indigo-600"}`} />
               {(sidebarOpen || mobile) && <span className="truncate">{label}</span>}
             </Link>
           );
@@ -121,8 +123,11 @@ export default function Layout({ children }: { children: React.ReactNode }) {
       {/* Footer */}
       <div className="border-t border-gray-200 p-3 space-y-1 flex-shrink-0">
         {(sidebarOpen || mobile) && userName && (
-          <div className="px-3 py-2 text-xs text-gray-500 truncate">
-            <span className="font-medium text-gray-700">{userName}</span>
+          <div className="flex items-center gap-2 px-3 py-2 truncate">
+            <span className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full bg-indigo-600 text-xs font-bold text-white">
+              {userName.charAt(0).toUpperCase()}
+            </span>
+            <span className="truncate text-sm font-semibold text-indigo-600">{userName}</span>
           </div>
         )}
         <button
@@ -178,8 +183,10 @@ export default function Layout({ children }: { children: React.ReactNode }) {
           <button onClick={() => setMobileOpen(true)} className="p-1.5 text-gray-600 hover:text-gray-900">
             <Menu className="h-5 w-5" />
           </button>
-          <BrainCircuit className="h-5 w-5 text-indigo-600" />
-          <span className="font-bold text-gray-900">AI Talent Finder</span>
+          <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-gradient-to-br from-indigo-600 to-violet-600 text-white">
+            <BrainCircuit className="h-4 w-4" />
+          </div>
+          <span className="font-display font-bold text-gray-900">AI Talent Finder</span>
         </header>
 
         {/* scrollbar-gutter:stable reserves the scrollbar lane even when

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { Moon, Sun } from "lucide-react";
+import { useTheme } from "@/hooks/useTheme";
+
+/**
+ * Standalone dark/light switch for public pages (landing, login, register),
+ * where the sidebar toggle from Layout is not available.
+ */
+export default function ThemeToggle({ className = "" }: { className?: string }) {
+  const { theme, toggleTheme } = useTheme();
+  const isDark = theme === "dark";
+
+  return (
+    <button
+      type="button"
+      onClick={toggleTheme}
+      aria-label={isDark ? "Activer le mode clair" : "Activer le mode sombre"}
+      title={isDark ? "Mode clair" : "Mode sombre"}
+      className={`inline-flex h-9 w-9 items-center justify-center rounded-lg border border-slate-300 bg-white text-slate-700 transition hover:bg-slate-100 ${className}`}
+    >
+      {isDark ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+    </button>
+  );
+}


### PR DESCRIPTION
Introduce a cohesive premium design system and apply it to every screen in light and dark mode.

Design system (globals.css + layout.tsx):
- Premium fonts: Inter (body) + Plus Jakarta Sans (display headings)
- Brand tokens, reusable classes: btn-primary, btn-ghost, card-premium, card-glow, glass-panel, glass-nav, pill, gradient-text, aurora, grid-overlay
- Entrance/keyframe animations with prefers-reduced-motion guard

Public pages: landing (vibrant aurora hero, glass dashboard mockup, steps, testimonial, accordion FAQ), login, register. New ThemeToggle for logged-out dark/light switching.

App: sidebar shell, recruiter/candidate/admin dashboards, candidates list + detail, matching, chatbot, upload, profile + edit, shortlist, skills, export, admin users/jobs/monitoring/pipeline, feedback, scoring, jobs, demo, admin-login.

Fixes:
- Remove test-account block from login
- Dark-mode legibility: violet/cyan overrides, bg-gray-200, translucent navs
- CRITICAL: replace hsl(var()/alpha) in --elev tokens with rgba(); Lightning CSS was silently dropping the entire premium CSS block (broke prod build too)