### PR TITLE
feat(auth): add password reset via email

### DIFF
--- a/backend/alembic/versions/add_password_reset_columns.py
+++ b/backend/alembic/versions/add_password_reset_columns.py
@@ -1,0 +1,29 @@
+"""add password reset columns to users
+
+Revision ID: add_password_reset
+Revises: add_ner_extraction
+Create Date: 2026-06-24 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'add_password_reset'
+down_revision: Union[str, None] = 'add_ner_extraction'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('users', sa.Column('reset_password_token', sa.String(), nullable=True))
+    op.add_column('users', sa.Column('reset_password_token_expires', sa.DateTime(), nullable=True))
+    op.create_index(op.f('ix_users_reset_password_token'), 'users', ['reset_password_token'], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f('ix_users_reset_password_token'), table_name='users')
+    op.drop_column('users', 'reset_password_token_expires')
+    op.drop_column('users', 'reset_password_token')

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -3,10 +3,11 @@ Authentication API endpoints - ÉTAPE 3 COMPLÈTE
 This module handles user registration, login, and token generation.
 """
 
-from fastapi import APIRouter, Depends, status, HTTPException, Header
+from fastapi import APIRouter, Depends, status, HTTPException, Header, BackgroundTasks
 from sqlalchemy.orm import Session
 from typing import Optional
-from datetime import datetime
+from datetime import datetime, timedelta
+import secrets
 
 from app.core.security import (
     get_password_hash,
@@ -16,8 +17,14 @@ from app.core.security import (
     ACCESS_TOKEN_EXPIRE_MINUTES,
 )
 from app.core.dependencies import get_db, get_current_user, log_activity
-from app.schemas.user import UserCreate, UserLogin, UserResponse, Token, TokenData
+from app.schemas.user import (
+    UserCreate, UserLogin, UserResponse, Token, TokenData,
+    ForgotPasswordRequest, ResetPasswordRequest, MessageResponse,
+)
 from app.models.models import User, UserRole as DBUserRole
+from app.services.email import send_password_reset_email
+
+PASSWORD_RESET_TOKEN_EXPIRE_HOURS = 2
 
 
 router = APIRouter(prefix="/api/auth", tags=["authentication"])
@@ -130,6 +137,55 @@ async def login(user_login: UserLogin, db: Session = Depends(get_db)) -> Token:
             created_at=db_user.created_at.isoformat()
         )
     )
+
+
+@router.post("/forgot-password", response_model=MessageResponse)
+async def forgot_password(
+    request: ForgotPasswordRequest,
+    background_tasks: BackgroundTasks,
+    db: Session = Depends(get_db),
+) -> MessageResponse:
+    """
+    Request a password reset link.
+    Always returns the same message to avoid email enumeration.
+    """
+    user = db.query(User).filter(User.email == request.email).first()
+    if user:
+        token = secrets.token_urlsafe(32)
+        user.reset_password_token = token
+        user.reset_password_token_expires = datetime.utcnow() + timedelta(hours=PASSWORD_RESET_TOKEN_EXPIRE_HOURS)
+        db.commit()
+        background_tasks.add_task(send_password_reset_email, user.email, token)
+    return MessageResponse(
+        message="Si un compte existe avec cet email, un lien de réinitialisation a été envoyé."
+    )
+
+
+@router.post("/reset-password", response_model=MessageResponse)
+async def reset_password(
+    request: ResetPasswordRequest,
+    db: Session = Depends(get_db),
+) -> MessageResponse:
+    """
+    Reset password using a valid reset token.
+    """
+    user = db.query(User).filter(User.reset_password_token == request.token).first()
+    if not user or not user.reset_password_token_expires:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Lien de réinitialisation invalide ou expiré."
+        )
+    if datetime.utcnow() > user.reset_password_token_expires:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Lien de réinitialisation invalide ou expiré."
+        )
+    user.hashed_password = get_password_hash(request.new_password)
+    user.reset_password_token = None
+    user.reset_password_token_expires = None
+    db.commit()
+    log_activity(db, "auth.reset_password", user_id=user.id, detail=f"Mot de passe réinitialisé pour {user.email}")
+    return MessageResponse(message="Mot de passe réinitialisé avec succès.")
 
 
 @router.get("/me", response_model=UserResponse)

--- a/backend/app/models/models.py
+++ b/backend/app/models/models.py
@@ -40,6 +40,8 @@ class User(Base):
     role = Column(Enum(UserRole), default=UserRole.recruiter, nullable=False)
     is_active = Column(Boolean, default=True, nullable=False)
     created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    reset_password_token = Column(String, nullable=True, index=True)
+    reset_password_token_expires = Column(DateTime, nullable=True)
 
     # Relationships
     job_criteria = relationship("JobCriteria", back_populates="recruiter")

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -46,3 +46,16 @@ class UserResponse(BaseModel):
 
     class Config:
         from_attributes = True
+
+
+class ForgotPasswordRequest(BaseModel):
+    email: EmailStr
+
+
+class ResetPasswordRequest(BaseModel):
+    token: str
+    new_password: str = Field(..., min_length=6)
+
+
+class MessageResponse(BaseModel):
+    message: str

--- a/backend/app/services/email.py
+++ b/backend/app/services/email.py
@@ -1,0 +1,80 @@
+import os
+import smtplib
+import asyncio
+from email.mime.text import MIMEText
+from email.mime.multipart import MIMEMultipart
+from functools import partial
+
+
+SMTP_HOST = os.getenv("SMTP_HOST", "smtp.gmail.com")
+SMTP_PORT = int(os.getenv("SMTP_PORT", "587"))
+SMTP_USER = os.getenv("SMTP_USER", "")
+SMTP_PASSWORD = os.getenv("SMTP_PASSWORD", "")
+SMTP_FROM_EMAIL = os.getenv("SMTP_FROM_EMAIL", SMTP_USER)
+SMTP_FROM_NAME = os.getenv("SMTP_FROM_NAME", "AI Talent Finder")
+FRONTEND_URL = os.getenv("FRONTEND_URL", "http://localhost:3000")
+
+
+def _send_email_sync(to_email: str, subject: str, html_body: str) -> None:
+    msg = MIMEMultipart("alternative")
+    msg["Subject"] = subject
+    msg["From"] = f"{SMTP_FROM_NAME} <{SMTP_FROM_EMAIL}>"
+    msg["To"] = to_email
+    msg.attach(MIMEText(html_body, "html"))
+
+    with smtplib.SMTP(SMTP_HOST, SMTP_PORT) as server:
+        server.ehlo()
+        server.starttls()
+        server.login(SMTP_USER, SMTP_PASSWORD)
+        server.sendmail(SMTP_FROM_EMAIL, to_email, msg.as_string())
+
+
+async def send_email(to_email: str, subject: str, html_body: str) -> None:
+    loop = asyncio.get_event_loop()
+    await loop.run_in_executor(None, partial(_send_email_sync, to_email, subject, html_body))
+
+
+async def send_password_reset_email(to_email: str, reset_token: str) -> None:
+    reset_url = f"{FRONTEND_URL}/auth/reset-password?token={reset_token}"
+    subject = "Réinitialisation de votre mot de passe – AI Talent Finder"
+    html_body = f"""
+    <!DOCTYPE html>
+    <html lang="fr">
+    <head><meta charset="UTF-8"></head>
+    <body style="font-family: Arial, sans-serif; background: #f8fafc; padding: 40px 0;">
+      <div style="max-width: 520px; margin: 0 auto; background: #fff; border-radius: 16px;
+                  border: 1px solid #e2e8f0; padding: 40px;">
+        <div style="text-align: center; margin-bottom: 32px;">
+          <div style="display: inline-block; background: linear-gradient(135deg, #4f46e5, #6366f1);
+                      border-radius: 12px; padding: 12px 16px;">
+            <span style="color: #fff; font-weight: 800; font-size: 18px;">AI Talent Finder</span>
+          </div>
+        </div>
+        <h2 style="color: #0f172a; font-size: 22px; margin: 0 0 12px;">
+          Réinitialisation de votre mot de passe
+        </h2>
+        <p style="color: #475569; font-size: 15px; line-height: 1.6; margin: 0 0 28px;">
+          Nous avons reçu une demande de réinitialisation du mot de passe associé à votre compte
+          <strong>{to_email}</strong>. Cliquez sur le bouton ci-dessous pour choisir un nouveau mot de passe.
+        </p>
+        <div style="text-align: center; margin-bottom: 28px;">
+          <a href="{reset_url}"
+             style="display: inline-block; background: linear-gradient(135deg, #4f46e5, #6366f1);
+                    color: #fff; text-decoration: none; padding: 14px 32px;
+                    border-radius: 10px; font-weight: 700; font-size: 15px;">
+            Réinitialiser mon mot de passe
+          </a>
+        </div>
+        <p style="color: #94a3b8; font-size: 13px; line-height: 1.6; margin: 0 0 8px;">
+          Ce lien est valable pendant <strong>2 heures</strong>. Si vous n'avez pas fait cette demande,
+          ignorez simplement cet email.
+        </p>
+        <hr style="border: none; border-top: 1px solid #e2e8f0; margin: 24px 0;">
+        <p style="color: #cbd5e1; font-size: 12px; text-align: center; margin: 0;">
+          &copy; 2026 AI Talent Finder. Tous droits réservés.
+        </p>
+      </div>
+    </body>
+    </html>
+    """
+    await send_email(to_email, subject, html_body)

--- a/frontend/src/app/auth/forgot-password/page.tsx
+++ b/frontend/src/app/auth/forgot-password/page.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { ArrowLeft, Sparkles, ShieldCheck } from 'lucide-react';
+import { authApi } from '@/services/auth';
+import { getErrorMessage } from '@/utils/errorHandler';
+import ThemeToggle from '@/components/ThemeToggle';
+
+export default function ForgotPasswordPage() {
+  const [email, setEmail] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [success, setSuccess] = useState(false);
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    setIsLoading(true);
+    try {
+      await authApi.forgotPassword(email);
+      setSuccess(true);
+    } catch (err: unknown) {
+      setError(getErrorMessage(err));
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="relative min-h-screen overflow-hidden bg-slate-50 text-slate-900">
+      <div className="aurora">
+        <div className="aurora-orb left-[-8%] top-[-6%] h-80 w-80 bg-blue-400" />
+        <div className="aurora-orb right-[-6%] bottom-[2%] h-96 w-96 bg-violet-400" style={{ animationDelay: '-5s' }} />
+        <div className="grid-overlay absolute inset-0 opacity-50" />
+      </div>
+
+      <nav className="glass-nav border-b border-slate-200 backdrop-blur-xl">
+        <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-3.5 sm:px-6 lg:px-8">
+          <Link href="/" className="flex items-center gap-3">
+            <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-gradient-to-br from-blue-600 to-indigo-600 text-white shadow-lg shadow-indigo-300/50">
+              <Sparkles className="h-5 w-5" />
+            </div>
+            <div>
+              <p className="text-[0.7rem] font-bold uppercase tracking-[0.18em] text-indigo-600">AI Recruiting</p>
+              <p className="font-display text-lg font-bold leading-none text-slate-900">AI Talent Finder</p>
+            </div>
+          </Link>
+          <div className="flex items-center gap-3">
+            <ThemeToggle />
+            <Link href="/auth/login" className="text-sm font-semibold text-slate-700 transition hover:text-indigo-600">
+              Se connecter
+            </Link>
+          </div>
+        </div>
+      </nav>
+
+      <div className="mx-auto flex min-h-[calc(100vh-69px)] w-full max-w-md items-center px-4 py-12 sm:px-6">
+        <div className="card-premium anim-pop w-full p-8 sm:p-9">
+          <Link
+            href="/auth/login"
+            className="mb-6 inline-flex items-center gap-1.5 text-sm font-medium text-slate-500 transition hover:text-indigo-600"
+          >
+            <ArrowLeft className="h-4 w-4" /> Retour à la connexion
+          </Link>
+
+          <div className="mb-7">
+            <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-indigo-500 to-violet-500 text-white shadow-md">
+              <ShieldCheck className="h-6 w-6" />
+            </div>
+            <h2 className="font-display text-3xl font-extrabold text-slate-900">Mot de passe oublié</h2>
+            <p className="mt-1.5 text-slate-600">
+              Renseignez votre email et nous vous enverrons un lien pour réinitialiser votre mot de passe.
+            </p>
+          </div>
+
+          {success ? (
+            <div
+              role="status"
+              className="rounded-xl border border-emerald-200 bg-emerald-50 px-5 py-4 text-sm font-medium text-emerald-700"
+            >
+              Si un compte est associé à cet email, vous recevrez un lien de réinitialisation dans quelques minutes.
+              Pensez à vérifier vos spams.
+            </div>
+          ) : (
+            <form onSubmit={handleSubmit} className="space-y-5">
+              <div>
+                <label htmlFor="email" className="mb-2 block text-sm font-semibold text-slate-800">
+                  Adresse email
+                </label>
+                <input
+                  id="email"
+                  type="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  placeholder="votre@email.com"
+                  className="w-full rounded-xl border border-slate-300 bg-white px-4 py-3 text-slate-900 outline-none transition focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200"
+                  required
+                  aria-required="true"
+                />
+              </div>
+
+              {error && (
+                <div
+                  role="alert"
+                  aria-live="assertive"
+                  className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm font-medium text-red-700"
+                >
+                  {error}
+                </div>
+              )}
+
+              <button
+                type="submit"
+                disabled={isLoading}
+                className="btn-primary w-full disabled:cursor-not-allowed disabled:opacity-70"
+              >
+                {isLoading ? 'Envoi en cours...' : 'Envoyer le lien de réinitialisation'}
+              </button>
+            </form>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/auth/login/page.tsx
+++ b/frontend/src/app/auth/login/page.tsx
@@ -123,9 +123,17 @@ export default function LoginPage() {
             </div>
 
             <div>
-              <label htmlFor="password" className="mb-2 block text-sm font-semibold text-slate-800">
-                Mot de passe
-              </label>
+              <div className="mb-2 flex items-center justify-between">
+                <label htmlFor="password" className="text-sm font-semibold text-slate-800">
+                  Mot de passe
+                </label>
+                <Link
+                  href="/auth/forgot-password"
+                  className="text-xs font-medium text-indigo-600 transition hover:text-indigo-700"
+                >
+                  Mot de passe oublié ?
+                </Link>
+              </div>
               <input
                 id="password"
                 type="password"

--- a/frontend/src/app/auth/reset-password/page.tsx
+++ b/frontend/src/app/auth/reset-password/page.tsx
@@ -1,0 +1,179 @@
+'use client';
+
+import { useState, useEffect, Suspense } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import Link from 'next/link';
+import { ArrowLeft, Sparkles, KeyRound, Eye, EyeOff } from 'lucide-react';
+import { authApi } from '@/services/auth';
+import { getErrorMessage } from '@/utils/errorHandler';
+import ThemeToggle from '@/components/ThemeToggle';
+
+function ResetPasswordForm() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const token = searchParams.get('token') ?? '';
+
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [success, setSuccess] = useState(false);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (!token) {
+      setError('Lien de réinitialisation invalide. Veuillez refaire une demande.');
+    }
+  }, [token]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+
+    if (newPassword !== confirmPassword) {
+      setError('Les mots de passe ne correspondent pas.');
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      await authApi.resetPassword(token, newPassword);
+      setSuccess(true);
+      setTimeout(() => router.push('/auth/login'), 3000);
+    } catch (err: unknown) {
+      setError(getErrorMessage(err));
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="card-premium anim-pop w-full p-8 sm:p-9">
+      <Link
+        href="/auth/login"
+        className="mb-6 inline-flex items-center gap-1.5 text-sm font-medium text-slate-500 transition hover:text-indigo-600"
+      >
+        <ArrowLeft className="h-4 w-4" /> Retour à la connexion
+      </Link>
+
+      <div className="mb-7">
+        <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-indigo-500 to-violet-500 text-white shadow-md">
+          <KeyRound className="h-6 w-6" />
+        </div>
+        <h2 className="font-display text-3xl font-extrabold text-slate-900">Nouveau mot de passe</h2>
+        <p className="mt-1.5 text-slate-600">Choisissez un nouveau mot de passe sécurisé.</p>
+      </div>
+
+      {success ? (
+        <div
+          role="status"
+          className="rounded-xl border border-emerald-200 bg-emerald-50 px-5 py-4 text-sm font-medium text-emerald-700"
+        >
+          Mot de passe réinitialisé avec succès ! Vous allez être redirigé vers la page de connexion…
+        </div>
+      ) : (
+        <form onSubmit={handleSubmit} className="space-y-5">
+          <div>
+            <label htmlFor="new-password" className="mb-2 block text-sm font-semibold text-slate-800">
+              Nouveau mot de passe
+            </label>
+            <div className="relative">
+              <input
+                id="new-password"
+                type={showPassword ? 'text' : 'password'}
+                value={newPassword}
+                onChange={(e) => setNewPassword(e.target.value)}
+                placeholder="••••••••"
+                className="w-full rounded-xl border border-slate-300 bg-white px-4 py-3 pr-11 text-slate-900 outline-none transition focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200"
+                required
+                minLength={6}
+                aria-required="true"
+              />
+              <button
+                type="button"
+                onClick={() => setShowPassword((v) => !v)}
+                className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 transition hover:text-slate-600"
+                aria-label={showPassword ? 'Masquer le mot de passe' : 'Afficher le mot de passe'}
+              >
+                {showPassword ? <EyeOff className="h-5 w-5" /> : <Eye className="h-5 w-5" />}
+              </button>
+            </div>
+          </div>
+
+          <div>
+            <label htmlFor="confirm-password" className="mb-2 block text-sm font-semibold text-slate-800">
+              Confirmer le mot de passe
+            </label>
+            <input
+              id="confirm-password"
+              type={showPassword ? 'text' : 'password'}
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              placeholder="••••••••"
+              className="w-full rounded-xl border border-slate-300 bg-white px-4 py-3 text-slate-900 outline-none transition focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200"
+              required
+              minLength={6}
+              aria-required="true"
+            />
+          </div>
+
+          {error && (
+            <div
+              role="alert"
+              aria-live="assertive"
+              className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm font-medium text-red-700"
+            >
+              {error}
+            </div>
+          )}
+
+          <button
+            type="submit"
+            disabled={isLoading || !token}
+            className="btn-primary w-full disabled:cursor-not-allowed disabled:opacity-70"
+          >
+            {isLoading ? 'Réinitialisation...' : 'Réinitialiser le mot de passe'}
+          </button>
+        </form>
+      )}
+    </div>
+  );
+}
+
+export default function ResetPasswordPage() {
+  return (
+    <div className="relative min-h-screen overflow-hidden bg-slate-50 text-slate-900">
+      <div className="aurora">
+        <div className="aurora-orb left-[-8%] top-[-6%] h-80 w-80 bg-blue-400" />
+        <div className="aurora-orb right-[-6%] bottom-[2%] h-96 w-96 bg-violet-400" style={{ animationDelay: '-5s' }} />
+        <div className="grid-overlay absolute inset-0 opacity-50" />
+      </div>
+
+      <nav className="glass-nav border-b border-slate-200 backdrop-blur-xl">
+        <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-3.5 sm:px-6 lg:px-8">
+          <Link href="/" className="flex items-center gap-3">
+            <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-gradient-to-br from-blue-600 to-indigo-600 text-white shadow-lg shadow-indigo-300/50">
+              <Sparkles className="h-5 w-5" />
+            </div>
+            <div>
+              <p className="text-[0.7rem] font-bold uppercase tracking-[0.18em] text-indigo-600">AI Recruiting</p>
+              <p className="font-display text-lg font-bold leading-none text-slate-900">AI Talent Finder</p>
+            </div>
+          </Link>
+          <div className="flex items-center gap-3">
+            <ThemeToggle />
+            <Link href="/auth/login" className="text-sm font-semibold text-slate-700 transition hover:text-indigo-600">
+              Se connecter
+            </Link>
+          </div>
+        </div>
+      </nav>
+
+      <div className="mx-auto flex min-h-[calc(100vh-69px)] w-full max-w-md items-center px-4 py-12 sm:px-6">
+        <Suspense fallback={<div className="card-premium w-full p-8 text-center text-slate-500">Chargement…</div>}>
+          <ResetPasswordForm />
+        </Suspense>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -63,4 +63,14 @@ export const authApi = {
     localStorage.removeItem('user_id');
     localStorage.removeItem('user');
   },
+
+  forgotPassword: async (email: string): Promise<{ message: string }> => {
+    const response = await apiClient.post('/auth/forgot-password', { email });
+    return response.data;
+  },
+
+  resetPassword: async (token: string, new_password: string): Promise<{ message: string }> => {
+    const response = await apiClient.post('/auth/reset-password', { token, new_password });
+    return response.data;
+  },
 };


### PR DESCRIPTION
- Add reset_password_token and reset_password_token_expires fields to User model
- Add Alembic migration to apply schema changes
- Add email service using native smtplib (no new dependency)
- Add POST /api/auth/forgot-password and /api/auth/reset-password endpoints
- Add forgot-password and reset-password pages in Next.js
- Add "Mot de passe oublié ?" link on the login page