### PR TITLE
feat(admin): restrict admin registration and seed admin via env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,9 @@ CV_UPLOAD_DIR=./uploads/cvs
 
 # Frontend
 NEXT_PUBLIC_API_URL=http://localhost:8000
+
+# Admin account (created automatically on backend startup if not exists)
+# Keep these secret — anyone with these credentials has full admin access
+ADMIN_EMAIL=admin@yourdomain.com
+ADMIN_PASSWORD=change-me-strong-password
+ADMIN_FULL_NAME=Admin

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -59,7 +59,7 @@ async def register(user_create: UserCreate, db: Session = Depends(get_db)) -> To
             email=user_create.email,
             hashed_password=hashed_password,
             full_name=user_create.full_name,
-            role=DBUserRole(user_create.role.value),
+            role=DBUserRole(user_create.role.value),  # recruiter or candidate only
         )
         db.add(db_user)
         db.commit()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -106,6 +106,42 @@ def on_startup():
     except Exception as e:
         logging.warning("Could not preload pipeline config: %s", e)
 
+    # Seed the admin account from environment variables.
+    # If ADMIN_EMAIL and ADMIN_PASSWORD are set and no account with that email
+    # exists yet, create it automatically with the admin role.
+    admin_email = os.getenv("ADMIN_EMAIL", "").strip()
+    admin_password = os.getenv("ADMIN_PASSWORD", "").strip()
+    admin_name = os.getenv("ADMIN_FULL_NAME", "Admin").strip()
+    if admin_email and admin_password:
+        try:
+            from app.core.database import SessionLocal
+            from app.core.security import get_password_hash
+            from app.models.models import User as UserModel, UserRole as DBUserRole
+            _db = SessionLocal()
+            try:
+                existing = _db.query(UserModel).filter(UserModel.email == admin_email).first()
+                if existing:
+                    if existing.role != DBUserRole.admin:
+                        existing.role = DBUserRole.admin
+                        _db.commit()
+                        logging.info("Admin role enforced for: %s", admin_email)
+                else:
+                    admin_user = UserModel(
+                        email=admin_email,
+                        hashed_password=get_password_hash(admin_password),
+                        full_name=admin_name,
+                        role=DBUserRole.admin,
+                    )
+                    _db.add(admin_user)
+                    _db.commit()
+                    logging.info("Admin account created: %s", admin_email)
+            finally:
+                _db.close()
+        except Exception as e:
+            logging.warning("Could not seed admin account: %s", e)
+    else:
+        logging.warning("ADMIN_EMAIL or ADMIN_PASSWORD not set — no admin account seeded.")
+
     # Conditionally include API routers. If a router import fails (e.g. heavy
     # ML dependencies missing), the app still starts and exposes /health.
     include_optional_router("app.api.auth")

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -9,12 +9,18 @@ class UserRole(str, Enum):
     candidate = "candidate"
 
 
+class UserRolePublic(str, Enum):
+    """Roles available for public self-registration — admin is excluded."""
+    recruiter = "recruiter"
+    candidate = "candidate"
+
+
 class UserCreate(BaseModel):
-    """Schema for user registration"""
+    """Schema for user registration — admin role is not allowed."""
     email: EmailStr
     password: str = Field(..., min_length=6)
     full_name: str = Field(..., min_length=2)
-    role: UserRole = UserRole.recruiter
+    role: UserRolePublic = UserRolePublic.recruiter
 
 
 class UserLogin(BaseModel):


### PR DESCRIPTION
- Remove admin from public registration: UserRolePublic enum only allows recruiter and candidate, preventing anyone from self-registering as admin
- Auto-seed admin account on startup from ADMIN_EMAIL + ADMIN_PASSWORD env vars (creates the account if it does not exist, enforces admin role if it does)
- Add ADMIN_EMAIL, ADMIN_PASSWORD, ADMIN_FULL_NAME to .env.example